### PR TITLE
Wft 186 translate templates endpoint docs

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -95,7 +95,6 @@ overrides:
       schema-property-descriptions: off
       schema-property-examples: off
     files:
-      - '**#/components/schemas/template' # Template Endpoint Schemas
       - '**#/components/schemas/responseTemplatePattern' # Response Template Endpoint Schemas
       - '**#/components/schemas/responseRule'
       - '**#/components/schemas/contact' # Contact Endpoint Schemas

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -87,7 +87,7 @@ rules:
     given: $.components.schemas.[*]..properties[?(@ && @.type && @.type !== "array" && @.type !== "object" && @.type !== "boolean" && !@.enum)]
     then:
       field: example
-      function: truthy
+      function: defined
   response-examples:
     description: Response content must have non-empty "examples" object.
     severity: error
@@ -110,10 +110,10 @@ rules:
   response-schema-property-examples:
     description: Response schema properties must have an "example".
     severity: error
-    given: $..responses..schema[*]..properties[?(@ && @.type && @.type !== "array" && @.type !== "object" && !@.enum)]
+    given: $..responses..schema[*]..properties[?(@ && @.type && @.type !== "array" && @.type !== "object" && @.type !== "boolean" && !@.enum)]
     then:
       field: example
-      function: truthy
+      function: defined
 overrides:
   - rules:
       schema-examples: off

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -84,7 +84,7 @@ rules:
   schema-property-examples: # Note: this rule is not de-duplicated, and will show on parents $ref'ing children with issues until all child issues are resolved.
     description: Schema properties must have an "example".
     severity: error
-    given: $.components.schemas.[*]..properties[?(@ && @.type && @.type !== "array" && @.type !== "object" && !@.enum)]
+    given: $.components.schemas.[*]..properties[?(@ && @.type && @.type !== "array" && @.type !== "object" && @.type !== "boolean" && !@.enum)]
     then:
       field: example
       function: truthy

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5693,10 +5693,6 @@ components:
                 type: string
                 minLength: 1
                 example: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
-            required:
-              - errorSummary
-              - errorText
-              - errorDetail
           examples:
             example-1:
               value:
@@ -5721,7 +5717,7 @@ components:
               errorSummary:
                 type: string
                 minLength: 1
-                example: '"Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
+                example: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
               errorText:
                 type: string
                 minLength: 1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1265,47 +1265,22 @@ paths:
                           type: string
                           minLength: 1
                           description: Specifies the name of the message template
+                          example: Test Template
                           readOnly: true
                         messageTemplateDescription:
                           type: string
                           minLength: 1
                           description: 'Specifies the description of the message template, so that anyone can understand its purpose'
+                          example: The test messate template.
                           readOnly: true
                         id:
                           type: string
                           minLength: 1
                           description: Specifies the template id needed for all the API Operations
+                          example: 236EA3E3E63439DA
                           readOnly: true
                         link:
-                          type: array
-                          uniqueItems: true
-                          minItems: 1
-                          description: Provides a list of URLs that can be used to manipulate or access the message template. This following attribute may return an empty array.
-                          items:
-                            type: object
-                            properties:
-                              uri:
-                                type: string
-                                minLength: 1
-                                description: The link to access the message template
-                                readOnly: true
-                              rel:
-                                type: string
-                                minLength: 1
-                                description: The descriptor for what the link will do
-                              method:
-                                type: string
-                                minLength: 1
-                                description: The HTTP method to use with this particular link
-                              host:
-                                type: string
-                                minLength: 1
-                                description: Host of the endpoint
-                              port:
-                                type: number
-                                description: Port number
-                            readOnly: true
-                          readOnly: true
+                          $ref: '#/components/schemas/link'
                     readOnly: true
                   link:
                     type: array
@@ -3738,66 +3713,7 @@ components:
             - true
           readOnly: true
         dlr:
-          description: A fixed object structure used by for Whispir internally for tracking purposes.
-          type: object
-          readOnly: true
-          required:
-            - period
-            - rule
-            - type
-            - publishToWeb
-            - expiryDay
-            - expiryHour
-            - expiryMin
-            - feedIds
-            - bool
-          properties:
-            period:
-              description: The period of the message delivery.
-              type: string
-              enum:
-                - ''
-            rule:
-              description: The rule of the message delivery.
-              type: string
-              enum:
-                - ''
-            type:
-              description: The type of the message delivery.
-              type: string
-              enum:
-                - ''
-            publishToWeb:
-              description: Specifies whether the message was published to the web.
-              type: boolean
-              enum:
-                - false
-                - true
-            expiryDay:
-              description: Specifies the number of days before the message expires.
-              type: number
-              enum:
-                - 0
-            expiryHour:
-              description: Specifies the number of hours before the message expires.
-              type: number
-              enum:
-                - 0
-            expiryMin:
-              description: Specifies the number of minutes before the message expires.
-              type: number
-              enum:
-                - 0
-            feedIds:
-              description: The feeds identifier for the message delivery.
-              type: string
-              enum:
-                - ''
-            bool:
-              description: The bool field for the message delivery.
-              type: boolean
-              enum:
-                - false
+          $ref: '#/components/schemas/dlr'
         link:
           $ref: '#/components/schemas/link'
       required:
@@ -4148,7 +4064,7 @@ components:
       x-tags:
         - Templates
       title: Template
-      description: The shape of the template request payload when creating one
+      description: The template object.
       x-examples:
         Template:
           messageTemplateName: Sample SMS Template
@@ -4242,102 +4158,13 @@ components:
         features:
           $ref: '#/components/schemas/features'
         dlr:
-          type: object
-          description: dlr stands for "delivery receipt" which has a fixed object structure and is used for Whispir internal tracking purposes.
-          properties:
-            period:
-              type: string
-              description: period of dlr
-              example: no example
-              readOnly: true
-            publishToWeb:
-              type: string
-              default: 'false'
-              description: publish to web flag
-              example: 'false'
-              readOnly: true
-            rule:
-              type: string
-              description: dlr rule
-              example: no example
-              readOnly: true
-            expiryDay:
-              type: number
-              default: 0
-              description: expiry duration in day
-              example: 1
-              readOnly: true
-            expiryHour:
-              type: number
-              default: 0
-              description: expiry duration in hour
-              example: 1
-              readOnly: true
-            expiryMin:
-              type: number
-              default: 0
-              description: expiry duration in minutes
-              example: 1
-              readOnly: true
-            feedIds:
-              type: string
-              description: Specifies the id of the feed
-              example: no example
-              readOnly: true
-            bool:
-              type: string
-              default: 'false'
-              example: 'false'
-              description: boolean
-            type:
-              type: string
-              description: Allows the user to modify the message behaviour for replies and DLRs (delivery receipts)
-              example: no example
-              readOnly: true
-          readOnly: true
+          $ref: '#/components/schemas/dlr'
         link:
-          type: array
-          description: Provides a list of URLs that can be used to manipulate or access the message template. This following attribute may return an empty array.
-          items:
-            type: object
-            properties:
-              uri:
-                type: string
-                description: The link to access the message template
-                example: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
-                readOnly: true
-              rel:
-                type: string
-                description: The descriptor for what the link will do
-                default: self
-                example: self
-                readOnly: true
-              method:
-                type: string
-                description: The HTTP method to use with this particular link
-                enum:
-                  - GET
-                  - PUT
-                  - DELETE
-                example: GET
-                readOnly: true
-              host:
-                type: string
-                description: Host of the endpoint
-                example: api.au.whispir.com
-                readOnly: true
-              port:
-                type: number
-                description: Port number of the endpoint
-                default: -1
-                example: -1
-                readOnly: true
-            readOnly: true
-          readOnly: true
+          $ref: '#/components/schemas/link'
         tags:
           type: string
           description: Information which helps to label related message templates together
-          example: internal
+          example: campaign
           readOnly: true
         id:
           type: string
@@ -5659,6 +5486,67 @@ components:
       required:
         - messageresponses
         - link
+    dlr:
+      title: Delivery Receipt
+      description: A fixed object structure used by for Whispir internally for tracking purposes.
+      type: object
+      readOnly: true
+      required:
+        - period
+        - rule
+        - type
+        - publishToWeb
+        - expiryDay
+        - expiryHour
+        - expiryMin
+        - feedIds
+        - bool
+      properties:
+        period:
+          description: The period of the message delivery.
+          type: string
+          example: ''
+        rule:
+          description: The rule of the message delivery.
+          type: string
+          example: ''
+        type:
+          description: The type of the message delivery.
+          type: string
+          example: ''
+        publishToWeb:
+          description: Specifies whether the message was published to the web.
+          type: boolean
+        expiryDay:
+          description: Specifies the number of days before the message expires.
+          type: number
+          example: 0
+        expiryHour:
+          description: Specifies the number of hours before the message expires.
+          type: number
+          example: 0
+        expiryMin:
+          description: Specifies the number of minutes before the message expires.
+          type: number
+          example: 0
+        feedIds:
+          description: The feeds identifier for the message delivery.
+          type: string
+          example: ''
+        bool:
+          description: The bool field for the message delivery.
+          type: boolean
+      x-examples:
+        Example:
+          period: ''
+          rule: ''
+          type: ''
+          publishToWeb: false
+          expiryDay: 0
+          expiryHour: 0
+          expiryMin: 0
+          feedIds: ''
+          bool: false
   parameters:
     X-Api-Key:
       name: X-Api-Key
@@ -5741,15 +5629,15 @@ components:
                     escalationMins: '3'
                     appId: appId
                 dlr:
-                  period: no example
-                  publishToWeb: 'false'
-                  rule: no example
-                  expiryDay: 1
-                  expiryHour: 1
-                  expiryMin: 1
-                  feedIds: no example
-                  bool: 'false'
-                  type: no example
+                  period: ''
+                  rule: ''
+                  type: ''
+                  publishToWeb: false
+                  expiryDay: 0
+                  expiryHour: 0
+                  expiryMin: 0
+                  feedIds: ''
+                  bool: false
                 link:
                   - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
                     rel: self

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1017,6 +1017,20 @@ paths:
       responses:
         '201':
           description: Created
+        '400':
+          $ref: '#/components/responses/400badRequest'
+        '401':
+          $ref: '#/components/responses/401unauthorised'
+        '403':
+          $ref: '#/components/responses/403forbidden'
+        '404':
+          $ref: '#/components/responses/404notFound'
+        '415':
+          $ref: '#/components/responses/415unsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422unprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500internalServerError'
     get:
       tags:
         - Templates
@@ -1044,44 +1058,20 @@ paths:
       parameters:
         - $ref: '#/components/parameters/x-api-key'
       responses:
-        '200':
-          description: OK
-          content:
-            examples:
-              examples:
-                response:
-                  value:
-                    status: '1 to 4 of 4    '
-                    messagetemplates:
-                      - messageTemplateName: Appointment Reminder
-                        messageTemplateDescription: ''
-                        id: F0547F6F2E4839F8
-                        link:
-                          - uri: 'https://api.au.whispir.com/templates/F0547F6F2E4839F8'
-                            rel: self
-                            method: GET
-                      - messageTemplateName: Customer Survey
-                        messageTemplateDescription: ''
-                        id: DDE10AC13FB0E457
-                        link:
-                          - uri: 'https://api.au.whispir.com/templates/DDE10AC13FB0E457'
-                            rel: self
-                            method: GET
-                      - messageTemplateName: Service announcement
-                        messageTemplateDescription: ''
-                        id: 900972D1C916FE84
-                        link:
-                          - uri: 'https://api.au.whispir.com/templates/900972D1C916FE84'
-                            rel: self
-                            method: GET
-                      - messageTemplateName: Shift Opportunity
-                        messageTemplateDescription: ''
-                        id: 9CB9BE20B885542D
-                        link:
-                          - uri: 'https://api.au.whispir.com/templates/9CB9BE20B885542D'
-                            rel: self
-                            method: GET
-                    link: []
+        '400':
+          $ref: '#/components/responses/400badRequest'
+        '401':
+          $ref: '#/components/responses/401unauthorised'
+        '403':
+          $ref: '#/components/responses/403forbidden'
+        '404':
+          $ref: '#/components/responses/404notFound'
+        '415':
+          $ref: '#/components/responses/415unsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422unprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500internalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/templates/{templateId}':
@@ -1102,53 +1092,21 @@ paths:
             example: 321D8505157C5F27
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/template'
-              examples:
-                sample response:
-                  value:
-                    messageTemplateName: Sample SMS Template
-                    messageTemplateDescription: Template to provide an example on whispir.io
-                    subject: Test SMS Message
-                    body: This is the body of my test SMS message
-                    responseTemplateId: string
-                    email:
-                      body: This is the body of my test Email message
-                      footer: This is the footer of my message (generally where a signature would go)
-                      type: text/plain
-                    voice:
-                      header: 'This is the introduction, read out prior to any key press'
-                      body: 'This is the body of the voice call, read out after the key press'
-                      type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
-                    web:
-                      body: This is the content of my web publishing or Rich Push Message
-                      type: text/plain
-                    social:
-                      social:
-                        - id: social_long
-                          body: Facebook Content.
-                          type: text/plain
-                    type: defaultNoReply
-                    features:
-                      pushOptions:
-                        notifications: enabled
-                        escalationMins: 3
-                    id: C23D6E2DD3D251BF
-                    tags: ''
-                    dir:
-                      period: ''
-                      rule: ''
-                      type: ''
-                      publishToWeb: false
-                      expiryDay: 0
-                      expiryHour: 0
-                      expiryMin: 0
-                      feedIds: ''
-                      bool: false
-                    link: []
+          $ref: '#/components/responses/template'
+        '400':
+          $ref: '#/components/responses/400badRequest'
+        '401':
+          $ref: '#/components/responses/401unauthorised'
+        '403':
+          $ref: '#/components/responses/403forbidden'
+        '404':
+          $ref: '#/components/responses/404notFound'
+        '415':
+          $ref: '#/components/responses/415unsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422unprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500internalServerError'
     put:
       tags:
         - Templates
@@ -1178,6 +1136,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400badRequest'
+        '401':
+          $ref: '#/components/responses/401unauthorised'
+        '403':
+          $ref: '#/components/responses/403forbidden'
+        '404':
+          $ref: '#/components/responses/404notFound'
+        '415':
+          $ref: '#/components/responses/415unsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422unprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500internalServerError'
     delete:
       tags:
         - Templates
@@ -1197,6 +1169,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400badRequest'
+        '401':
+          $ref: '#/components/responses/401unauthorised'
+        '403':
+          $ref: '#/components/responses/403forbidden'
+        '404':
+          $ref: '#/components/responses/404notFound'
+        '415':
+          $ref: '#/components/responses/415unsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422unprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500internalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/responserules':
@@ -3365,6 +3351,11 @@ components:
           schema:
             $ref: '#/components/schemas/event'
       description: events object that needs to be create events
+    template:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/template'
   securitySchemes:
     BasicAuth:
       type: http
@@ -3540,7 +3531,7 @@ components:
         - Templates
       title: Template
       x-examples:
-        example-1:
+        Template:
           messageTemplateName: Sample SMS Template
           messageTemplateDescription: Template to provide an example on whispir.io
           responseTemplateId: string
@@ -4212,22 +4203,26 @@ components:
     link:
       title: link
       type: object
-      description: 'related link of the retrieved resource '
       properties:
         uri:
           type: string
-          description: specifies assoiciated API endpoint that you can use to interact with the resource
+          example: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
         rel:
           type: string
+          example: self
         method:
           type: string
-          description: 'Operation method name (e.g. "GET","POST", etc)'
+          enum:
+            - GET
+            - POST
+            - DELETE
+            - PUT
         host:
           type: string
+          example: api.ap1.whispir.com
         port:
           type: integer
-        '':
-          type: string
+          example: -1
   parameters:
     x-api-key:
       name: x-api-key
@@ -4246,14 +4241,28 @@ components:
       description: The identifier for the workspace.
       required: true
   responses:
-    getTemplateById:
-      description: This is a sample response of retrieving a template
+    500internalServerError:
+      description: 500 Internal Server Error
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: INTERNAL SERVER ERROR
+          examples:
+            500 Internal Server Error:
+              value:
+                message: INTERNAL SERVER ERROR
+    template:
+      description: Example response of a template resource
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/template'
           examples:
-            Get a template sample response:
+            example-1:
               value:
                 messageTemplateName: Sample SMS Template
                 messageTemplateDescription: Template to provide an example on whispir.io
@@ -4309,3 +4318,192 @@ components:
                     method: DELETE
                     host: api.ap1.whispir.com
                     port: -1
+    400badRequest:
+      description: Example response of a 400 bad request error
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            x-examples:
+              example-1:
+                errorSummary: Your request was malformed and could not be processed by the server. Please try again
+                errorText: Bad Request
+                errorDetail: 'java.io.EOFException: No content to map to Object due to end of input'
+            properties:
+              errorSummary:
+                type: string
+                minLength: 1
+                example: Your request was malformed and could not be processed by the server. Please try again
+              errorText:
+                type: string
+                minLength: 1
+                example: Bad Request
+              errorDetail:
+                type: string
+                minLength: 1
+                example: 'java.io.EOFException: No content to map to Object due to end of input'
+              link:
+                type: array
+                items: {}
+          examples:
+            400 Bad Request:
+              value:
+                errorSummary: Your request was malformed and could not be processed by the server. Please try again
+                errorText: Bad Request
+                errorDetail: 'java.io.EOFException: No content to map to Object due to end of input'
+                link: []
+    401unauthorised:
+      description: 401 Unauthorized Error
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            x-examples:
+              example-1:
+                errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
+                errorText: Unauthorized
+                errorDetail: ''
+                link: []
+            properties:
+              errorSummary:
+                type: string
+                minLength: 1
+                example: Your username and password combination was incorrect. Please check your authentication details and try again
+              errorText:
+                type: string
+                minLength: 1
+                example: Unauthorized
+              errorDetail:
+                type: string
+              link:
+                type: array
+                items: {}
+          examples:
+            401 Unauthorized Error:
+              value:
+                errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
+                errorText: Unauthorized
+                errorDetail: ''
+                link: []
+    403forbidden:
+      description: 403 Forbidden Error
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: Forbidden
+          examples:
+            403 Forbidden:
+              value:
+                message: Forbidden
+    404notFound:
+      description: 404 Not Found Error
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            x-examples:
+              example-1:
+                errorSummary: The resource that you have requested does not exist. Please check the identifier and try again
+                errorText: Not Found
+                errorDetail: ''
+                link: []
+            properties:
+              errorSummary:
+                type: string
+                minLength: 1
+                example: The resource that you have requested does not exist. Please check the identifier and try again
+              errorText:
+                type: string
+                minLength: 1
+                example: Not Found
+              errorDetail:
+                type: string
+              link:
+                type: array
+                items: {}
+          examples:
+            example-1:
+              value:
+                errorSummary: The resource that you have requested does not exist. Please check the identifier and try again
+                errorText: Not Found
+                errorDetail: ''
+                link: []
+    415unsupportedMediaType:
+      description: 415 Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            x-examples:
+              example-1:
+                errorSummary: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
+                errorText: Unsupported Media Type
+                errorDetail: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
+                link: []
+            properties:
+              errorSummary:
+                type: string
+                minLength: 1
+                example: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
+              errorText:
+                type: string
+                minLength: 1
+                example: Unsupported Media Type
+              errorDetail:
+                type: string
+                minLength: 1
+                example: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
+              link:
+                type: array
+                items: {}
+          examples:
+            415 Unsupported Media Type:
+              value:
+                errorSummary: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
+                errorText: Unsupported Media Type
+                errorDetail: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
+                link: []
+    422unprocessibleEntity:
+      description: 422 Unprocessible Entitity
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            x-examples:
+              example-1:
+                errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
+                errorText: |
+                  A Template name already exists in the current Workspace, please select another name and try again.
+                errorDetail: ''
+                link: []
+            properties:
+              errorSummary:
+                type: string
+                minLength: 1
+                example: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
+              errorText:
+                type: string
+                minLength: 1
+                example: 'A Template name already exists in the current Workspace, please select another name and try again.\n'
+              errorDetail:
+                type: string
+              link:
+                type: array
+                items: {}
+          examples:
+            422 Unprocessable Entity:
+              value:
+                errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
+                errorText: 'A Template name already exists in the current Workspace, please select another name and try again.\n'
+                errorDetail: ''
+                link: []
+  examples: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1727,29 +1727,28 @@ paths:
       responses:
         '201':
           $ref: '#/components/responses/Template'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          description: Unsupported Media Type
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     get:
       tags:
         - Templates
       summary: List templates
       description: |
-        ## Response Elements
+        List all message templates for the workspace.
 
-        **messageTemplateName:** String
-
-        Specifies the name of the message template to be used within message requests.
-
-        **messageTemplateDescription:** String  
-        Specifies the description of the message template for others to understand it’s purpose.
-
-        **id:** String  
-        Specifies the ID of the template that can be used for message sending.
-
-        **link:** array  
-        Provides a list of URLs that can be used to manipulate or access the message template.
-
-        *   uri - the link to access the message template
-        *   rel - the descriptor for what the link will do
-        *   method - the HTTP method to use with this particular link
+        Pagination is available.
       operationId: getTemplates
       parameters:
         - $ref: '#/components/parameters/X-Api-Key'
@@ -1783,7 +1782,7 @@ paths:
                             port: -1
                     link: []
               schema:
-                description: ''
+                description: Returns a list of templates
                 type: object
                 x-examples:
                   example-1:
@@ -1870,6 +1869,12 @@ paths:
                   - status
                   - messagetemplates
                   - link
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/templates/{templateId}':
@@ -1877,7 +1882,7 @@ paths:
       tags:
         - Templates
       summary: Retrieve a template
-      description: Retrieves a Template object.
+      description: Retrieves a message template
       operationId: getTemplatesById
       parameters:
         - $ref: '#/components/parameters/X-Api-Key'
@@ -1902,6 +1907,20 @@ paths:
       responses:
         '201':
           $ref: '#/components/responses/Template'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     put:
       tags:
         - Templates
@@ -1931,6 +1950,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     delete:
       tags:
         - Templates
@@ -1950,6 +1983,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/responserules':
@@ -4568,6 +4615,46 @@ components:
       x-tags:
         - Templates
       title: Template
+      description: The shape of the template request payload when creating one
+      x-examples:
+        Template:
+          messageTemplateName: Sample SMS Template
+          messageTemplateDescription: Template to provide an example on whispir.io
+          responseTemplateId: responseTemplateId
+          subject: Test SMS Message
+          body: This is the body of my test SMS message
+          email:
+            body: This is the body of my email message.
+            footer: This is the footer of my message.
+            type: text/plain
+            resources:
+              attachments:
+                - attachmentName: photo.jpeg
+                  derefUri: iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==
+                  attachmentDesc: My photo
+          voice:
+            header: 'This is the introduction, read out to the recipient prior to any key press.'
+            body: 'This is the body of the voice call, read out after the key press'
+            type: 'Pin:7171,ConfCall:1800123123,ConfAccountNo:098711234,ConfPinNo:8181,ConfModPinNo:4242'
+            resources:
+              attachment:
+                - attachmentName: photo.jpeg
+                  derefUri: iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==
+                  attachmentDesc: My photo
+          web:
+            body: This is the content of my web publishing or Rich Push Message
+            type: text/plain
+          social:
+            social:
+              - id: social
+                body: Facebook Content
+                type: text/plain
+          type: defaultNoReply
+          features:
+            pushOptions:
+              notifications: enabled
+              escalationMins: '3'
+              appId: appId
     responseTemplatePattern:
       type: object
       properties:
@@ -5246,7 +5333,7 @@ components:
       content:
         application/json:
           schema:
-            description: ''
+            description: This is the shape of a template response
             type: object
             x-examples:
               example-1:
@@ -5337,6 +5424,16 @@ components:
                   bool:
                     type: boolean
                     default: false
+                required:
+                  - period
+                  - rule
+                  - type
+                  - publishToWeb
+                  - expiryDay
+                  - expiryHour
+                  - expiryMin
+                  - feedIds
+                  - bool
               body:
                 type: string
                 minLength: 1
@@ -5478,22 +5575,31 @@ components:
           schema:
             description: ''
             type: object
+            x-examples:
+              example-1:
+                errorSummary: Your request was malformed and could not be processed by the server. Please try again
+                errorText: Bad Request
+                errorDetail: 'java.io.EOFException: No content to map to Object due to end of input'
             properties:
               errorSummary:
                 type: string
                 minLength: 1
+                example: Your request was malformed and could not be processed by the server. Please try again
               errorText:
                 type: string
                 minLength: 1
+                example: Bad Request
               errorDetail:
                 type: string
                 minLength: 1
+                example: '"java.io.EOFException: No content to map to Object due to end of inpu'
             required:
               - errorSummary
               - errorText
               - errorDetail
-            x-examples:
-              example-1:
+          examples:
+            example-1:
+              value:
                 errorSummary: Your request was malformed and could not be processed by the server. Please try again
                 errorText: Bad Request
                 errorDetail: 'java.io.EOFException: No content to map to Object due to end of input'
@@ -5504,23 +5610,32 @@ components:
           schema:
             description: ''
             type: object
+            x-examples:
+              example-1:
+                links: null
+                errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
+                errorText: Unauthorized
+                errorDetail: ''
             properties:
               links: {}
               errorSummary:
                 type: string
                 minLength: 1
+                example: Your username and password combination was incorrect. Please check your authentication details and try again
               errorText:
                 type: string
                 minLength: 1
+                example: Unauthorised
               errorDetail:
                 type: string
             required:
               - errorSummary
               - errorText
               - errorDetail
-            x-examples:
-              example-1:
-                links: null
+          examples:
+            example-1:
+              value:
+                links: []
                 errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
                 errorText: Unauthorized
                 errorDetail: ''
@@ -5531,14 +5646,19 @@ components:
           schema:
             description: ''
             type: object
+            x-examples:
+              example-1:
+                message: Forbidden
             properties:
               message:
                 type: string
                 minLength: 1
+                example: Forbidden
             required:
               - message
-            x-examples:
-              example-1:
+          examples:
+            example-1:
+              value:
                 message: Forbidden
     404NotFound:
       description: 404 Not found Error
@@ -5547,28 +5667,31 @@ components:
           schema:
             description: ''
             type: object
+            x-examples:
+              example-1:
+                errorSummary: 'The resource that you have requested does not exist. Please check the identifier and try again '
+                errorText: Not Found
+                errorDetail: ''
+                link: []
             properties:
               errorSummary:
                 type: string
                 minLength: 1
+                example: The resource that you have requested does not exist. Please check the identifier and try again
               errorText:
                 type: string
                 minLength: 1
+                example: Not Found
               errorDetail:
                 type: string
               link:
                 type: array
                 items:
-                  required: []
-                  properties: {}
-            required:
-              - errorSummary
-              - errorText
-              - errorDetail
-              - link
-            x-examples:
-              example-1:
-                errorSummary: 'The resource that you have requested does not exist. Please check the identifier and try again '
+                  type: object
+          examples:
+            example-1:
+              value:
+                errorSummary: The resource that you have requested does not exist. Please check the identifier and try again
                 errorText: Not Found
                 errorDetail: ''
                 link: []
@@ -5579,22 +5702,31 @@ components:
           schema:
             description: ''
             type: object
+            x-examples:
+              example-1:
+                errorSummary: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
+                errorText: Unsupported Media Type
+                errorDetail: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
             properties:
               errorSummary:
                 type: string
                 minLength: 1
+                example: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
               errorText:
                 type: string
                 minLength: 1
+                example: Unsupported Media Type
               errorDetail:
                 type: string
                 minLength: 1
+                example: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
             required:
               - errorSummary
               - errorText
               - errorDetail
-            x-examples:
-              example-1:
+          examples:
+            example-1:
+              value:
                 errorSummary: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
                 errorText: Unsupported Media Type
                 errorDetail: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
@@ -5605,27 +5737,31 @@ components:
           schema:
             description: ''
             type: object
+            x-examples:
+              example-1:
+                errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
+                errorText: |
+                  A Template name already exists in the current Workspace, please select another name and try again.
+                errorDetail: ''
+                link: []
             properties:
               errorSummary:
                 type: string
                 minLength: 1
+                example: '"Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
               errorText:
                 type: string
                 minLength: 1
+                example: 'A Template name already exists in the current Workspace, please select another name and try again.'
               errorDetail:
                 type: string
               link:
                 type: array
                 items:
-                  required: []
-                  properties: {}
-            required:
-              - errorSummary
-              - errorText
-              - errorDetail
-              - link
-            x-examples:
-              example-1:
+                  type: object
+          examples:
+            example-1:
+              value:
                 errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
                 errorText: |
                   A Template name already exists in the current Workspace, please select another name and try again.
@@ -5640,6 +5776,7 @@ components:
             properties:
               message:
                 type: string
+                example: Internal Server Error
           examples:
             example-1:
               value:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1726,7 +1726,7 @@ paths:
         required: true
       responses:
         '201':
-          description: Created
+          $ref: '#/components/responses/Template'
     get:
       tags:
         - Templates
@@ -1759,39 +1759,117 @@ paths:
           content:
             examples:
               examples:
-                response:
+                A list of templates:
                   value:
-                    status: '1 to 4 of 4    '
+                    status: '1 to 2 of 2    '
                     messagetemplates:
-                      - messageTemplateName: Appointment Reminder
-                        messageTemplateDescription: ''
-                        id: F0547F6F2E4839F8
+                      - messageTemplateName: Sample SMS Template 2
+                        messageTemplateDescription: Template to provide an example on whispir.io no.1
+                        id: 236EA3E3E63439DA
                         link:
-                          - uri: 'https://api.au.whispir.com/templates/F0547F6F2E4839F8'
+                          - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/236EA3E3E63439DA'
                             rel: self
                             method: GET
-                      - messageTemplateName: Customer Survey
-                        messageTemplateDescription: ''
-                        id: DDE10AC13FB0E457
+                            host: api.au.whispir.com
+                            port: -1
+                      - messageTemplateName: Sample SMS Template with tags
+                        messageTemplateDescription: Template to provide an example on whispir.io no.1
+                        id: D09B63AD6BD1A503
                         link:
-                          - uri: 'https://api.au.whispir.com/templates/DDE10AC13FB0E457'
+                          - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/D09B63AD6BD1A503'
                             rel: self
                             method: GET
-                      - messageTemplateName: Service announcement
-                        messageTemplateDescription: ''
-                        id: 900972D1C916FE84
-                        link:
-                          - uri: 'https://api.au.whispir.com/templates/900972D1C916FE84'
-                            rel: self
-                            method: GET
-                      - messageTemplateName: Shift Opportunity
-                        messageTemplateDescription: ''
-                        id: 9CB9BE20B885542D
-                        link:
-                          - uri: 'https://api.au.whispir.com/templates/9CB9BE20B885542D'
-                            rel: self
-                            method: GET
+                            host: api.au.whispir.com
+                            port: -1
                     link: []
+              schema:
+                description: ''
+                type: object
+                x-examples:
+                  example-1:
+                    status: '1 to 1 of 1    '
+                    messagetemplates:
+                      - messageTemplateName: Sample SMS Template with tags
+                        messageTemplateDescription: Template to provide an example on whispir.io no.1
+                        id: 3148356543415EE7
+                        link:
+                          - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
+                            rel: self
+                            method: GET
+                            host: api.au.whispir.com
+                            port: -1
+                    link: []
+                properties:
+                  status:
+                    type: string
+                    minLength: 1
+                    example: 1 to 1 of 1
+                    description: Provides the total number of records fetched. This attribute may return "No records found" when there are no message templates available.
+                    readOnly: true
+                  messagetemplates:
+                    type: array
+                    uniqueItems: true
+                    minItems: 1
+                    description: Specifies the name of the message template
+                    items:
+                      type: object
+                      properties:
+                        messageTemplateName:
+                          type: string
+                          minLength: 1
+                          description: Specifies the name of the message template
+                          readOnly: true
+                        messageTemplateDescription:
+                          type: string
+                          minLength: 1
+                          description: 'Specifies the description of the message template, so that anyone can understand its purpose'
+                          readOnly: true
+                        id:
+                          type: string
+                          minLength: 1
+                          description: Specifies the template id needed for all the API Operations
+                          readOnly: true
+                        link:
+                          type: array
+                          uniqueItems: true
+                          minItems: 1
+                          description: Provides a list of URLs that can be used to manipulate or access the message template. This following attribute may return an empty array.
+                          items:
+                            type: object
+                            properties:
+                              uri:
+                                type: string
+                                minLength: 1
+                                description: The link to access the message template
+                                readOnly: true
+                              rel:
+                                type: string
+                                minLength: 1
+                                description: The descriptor for what the link will do
+                              method:
+                                type: string
+                                minLength: 1
+                                description: The HTTP method to use with this particular link
+                              host:
+                                type: string
+                                minLength: 1
+                                description: Host of the endpoint
+                              port:
+                                type: number
+                                description: Port number
+                            readOnly: true
+                          readOnly: true
+                    readOnly: true
+                  link:
+                    type: array
+                    description: Provides a list of URLs that can be used to manipulate or access the message template. This following attribute may return an empty array.
+                    items:
+                      type: object
+                    readOnly: true
+                required:
+                  - status
+                  - messagetemplates
+                  - link
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/templates/{templateId}':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -199,6 +199,20 @@ paths:
                 type: string
               example: 'https://api.au.whispir.com/workspaces/9A4C5521FFC7B15B/messages/747AB7E716C1802B6476784AEB5C9BB8'
               description: The URI to fetch details of the resource.
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     get:
       tags:
         - Messages
@@ -351,6 +365,20 @@ paths:
               $ref: '#/components/headers/Content-Length'
             Access-Control-Allow-Origin:
               $ref: '#/components/headers/Access-Control-Allow-Origin'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/messages/{messageId}':
@@ -464,6 +492,20 @@ paths:
                     validBody: true
                     validSubject: true
                     whatsappValidMessage: true
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       parameters:
         - $ref: '#/components/parameters/X-Api-Key'
         - name: Content-Type
@@ -673,6 +715,20 @@ paths:
                     link: []
               schema:
                 $ref: '#/components/schemas/messageStatus'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       tags:
         - Messages
     parameters:
@@ -850,6 +906,20 @@ paths:
                           acknowledged: '28/09/12 08:48'
                           channel: sms
                     link: []
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       tags:
         - Messages
     parameters:
@@ -915,6 +985,20 @@ paths:
             application/vnd.whispir.resource-v1+xml:
               schema:
                 $ref: '#/components/schemas/resource'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     get:
       tags:
         - Resources
@@ -1037,6 +1121,20 @@ paths:
                             method: GET
                     status: '1 to 7 of 7    '
                     link: []
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/resources/{resourceId}':
@@ -1078,6 +1176,20 @@ paths:
                       - uri: 'https://api.au.whispir.com/resources/D3E2XCDF3WS4859'
                         rel: deleteResource
                         method: DELETE
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     put:
       tags:
         - Resources
@@ -1128,6 +1240,20 @@ paths:
                         social:
                           - id: socialType
                             body: text/plain
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     delete:
       tags:
         - Resources
@@ -1149,8 +1275,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/templates':
@@ -1184,7 +1322,7 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
         '415':
-          description: Unsupported Media Type
+          $ref: '#/components/responses/415UnsupportedMediaType'
         '422':
           $ref: '#/components/responses/422UnprocessibleEntity'
         '500':
@@ -1474,6 +1612,20 @@ paths:
       responses:
         '201':
           description: Created
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     get:
       tags:
         - Response Rules
@@ -1485,6 +1637,20 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/responserules/{responseRuleId}':
@@ -1506,6 +1672,20 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     put:
       tags:
         - Response Rules
@@ -1534,6 +1714,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     delete:
       tags:
         - Response Rules
@@ -1552,6 +1746,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/contacts':
@@ -1584,6 +1792,20 @@ paths:
             application/vnd.whispir.contact-v1+xml:
               schema:
                 $ref: '#/components/schemas/contact'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     get:
       tags:
         - Contacts
@@ -1634,6 +1856,20 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/contacts/{contactId}':
@@ -1670,6 +1906,20 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     put:
       tags:
         - Contacts
@@ -1709,6 +1959,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     delete:
       tags:
         - Contacts
@@ -1730,6 +1994,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/distributionlists':
@@ -1779,6 +2057,20 @@ paths:
                       longitude: -122.3493552
                       latitude: 47.6204232
                       type: CurrentLocation
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     get:
       tags:
         - Distribution Lists
@@ -1839,6 +2131,20 @@ paths:
                             method: GET
                     status: '1 to 2 of 2    '
                     link: []
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/distributionlists/{distributionlistId}':
@@ -1884,6 +2190,20 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     put:
       tags:
         - Distribution Lists
@@ -1929,6 +2249,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     delete:
       tags:
         - Distribution Lists
@@ -1948,6 +2282,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/scenarios':
@@ -1973,6 +2321,20 @@ paths:
       responses:
         '201':
           description: Created
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     get:
       tags:
         - Scenarios
@@ -1984,6 +2346,20 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/scenarios/{scenarioId}':
@@ -2038,6 +2414,20 @@ paths:
                         rel: deleteScenario
                         method: DELETE
                         type: 'application/vnd.whispir.scenario-v1+json,application/vnd.whispir.scenario-v1+xml'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     post:
       tags:
         - Scenarios
@@ -2066,6 +2456,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     put:
       tags:
         - Scenarios
@@ -2094,6 +2498,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     delete:
       tags:
         - Scenarios
@@ -2112,6 +2530,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   /callbacks:
@@ -2159,6 +2591,20 @@ paths:
       responses:
         '201':
           description: Created
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       parameters:
         - $ref: '#/components/parameters/X-Api-Key'
     get:
@@ -2215,6 +2661,20 @@ paths:
                             rel: self
                             method: GET
                     link: []
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       parameters:
         - $ref: '#/components/parameters/X-Api-Key'
   '/callbacks/{callbackId}/calls':
@@ -2302,6 +2762,20 @@ paths:
                       - rel: next
                         uri: /callbacks/B384FD38DCBADE38/calls?limit=20&offset=20
                         method: GET
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     put:
       tags:
         - Callbacks
@@ -2351,6 +2825,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /workspaces:
     post:
       tags:
@@ -2372,6 +2860,20 @@ paths:
       responses:
         '201':
           description: Created
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       parameters:
         - $ref: '#/components/parameters/X-Api-Key'
     get:
@@ -2421,6 +2923,20 @@ paths:
                           - uri: 'https://api.au.whispir.com/workspaces/B7BFEF555F0F7F81'
                             rel: self
                             method: GET
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       parameters:
         - $ref: '#/components/parameters/X-Api-Key'
   '/workspaces/{workspaceId}':
@@ -2435,6 +2951,20 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   /activities:
@@ -2458,6 +2988,20 @@ paths:
       responses:
         '201':
           description: Created
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       parameters:
         - $ref: '#/components/parameters/X-Api-Key'
     get:
@@ -2635,8 +3179,20 @@ paths:
                             rel: self
                             method: GET
                     link: []
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   '/workspaces/{workspaceId}/activities':
     get:
       tags:
@@ -2651,6 +3207,20 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/customlists':
@@ -2784,8 +3354,20 @@ paths:
                             rel: self
                             method: GET
                     link: []
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/customlists/{customlistId}':
@@ -2866,8 +3448,20 @@ paths:
                       - uri: 'https://api.au.whispir.com/customlists/40E5D16229E2101D'
                         rel: self
                         method: GET
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   /users:
@@ -2935,6 +3529,20 @@ paths:
                       - uri: 'https://api.au.whispir.com/users/AF48A9EC3F02E43C'
                         rel: deleteUser
                         method: DELETE
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     get:
       tags:
         - Users
@@ -3021,7 +3629,20 @@ paths:
                           method: GET
                           rel: self
                           uri: 'http://api.whispir.com/users/AF48A9EC3F02E43C'
-                      - ...
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       x-internal: false
     delete:
       tags:
@@ -3037,6 +3658,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   '/users/{userId}':
     get:
       tags:
@@ -3069,6 +3704,20 @@ paths:
                       method: GET
                       rel: self
                       uri: 'http://api.whispir.com/users/AF48A9EC3F02E43C'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     put:
       tags:
         - Users
@@ -3110,6 +3759,20 @@ paths:
       responses:
         '204':
           description: Created
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     delete:
       tags:
         - Users
@@ -3131,6 +3794,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   '/workspaces/{workspaceId}/users':
     get:
       tags:
@@ -3173,6 +3850,20 @@ paths:
                           uri: 'https://api.au.whispir.com/workspaces/C727BCE3A813E2B1/users/?offset=10&limit=10'
                           rel: next
                           method: GET
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/events':
@@ -3194,6 +3885,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/event'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     post:
       tags:
         - Events
@@ -3332,6 +4037,20 @@ paths:
                       - uri: 'https://api.au.whispir.com/workspaces/26C20B1A09XS3RA2/messages?label=2701095%20-%20Outage%20of%20Local%20Systems%20in%20Sydney'
                         rel: retrieveEventMessages
                         method: GET
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/imports':
@@ -3383,6 +4102,20 @@ paths:
       responses:
         '201':
           description: Created
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   /auth:
@@ -3410,6 +4143,20 @@ paths:
                     type: array
                     items:
                       type: object
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       description: Create a JWT authentication token
       parameters:
         - schema:
@@ -3476,6 +4223,20 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
       summary: Verify an auth token
       tags:
         - Auth

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1719,57 +1719,14 @@ paths:
           application/vnd.whispir.template-v1+json:
             schema:
               $ref: '#/components/schemas/template'
-            examples:
-              The Template Object:
-                value:
-                  messageTemplateName: Sample SMS Template
-                  messageTemplateDescription: Template to provide an example on whispir.io
-                  subject: Test SMS Message
-                  body: This is the body of my test SMS message
-                  responseTemplateId: string
-                  email:
-                    body: This is the body of my test Email message
-                    footer: This is the footer of my message (generally where a signature would go)
-                    type: text/plain
-                  voice:
-                    header: 'This is the introduction, read out prior to any key press'
-                    body: 'This is the body of the voice call, read out after the key press'
-                    type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
-                  web:
-                    body: This is the content of my web publishing or Rich Push Message
-                    type: text/plain
-                  social:
-                    social:
-                      - id: social_long
-                        body: Facebook Content.
-                        type: text/plain
-                  type: defaultNoReply
-                  features:
-                    pushOptions:
-                      notifications: enabled
-                      escalationMins: 3
           application/vnd.whispir.template-v1+xml:
             schema:
               $ref: '#/components/schemas/template'
-        description: The template object
+        description: Templates object that needs to be create Templates
         required: true
       responses:
         '201':
-          $ref: '#/components/responses/Template'
-        '400':
-          $ref: '#/components/responses/400badRequest'
-        '401':
-          $ref: '#/components/responses/401unauthorised'
-        '403':
-          $ref: '#/components/responses/403forbidden'
-        '404':
-          $ref: '#/components/responses/404notFound'
-        '415':
-          $ref: '#/components/responses/415unsupportedMediaType'
-        '422':
-          $ref: '#/components/responses/422unprocessibleEntity'
-        '500':
-          $ref: '#/components/responses/500internalServerError'
+          description: Created
     get:
       tags:
         - Templates
@@ -1798,21 +1755,43 @@ paths:
         - $ref: '#/components/parameters/X-Api-Key'
       responses:
         '200':
-          $ref: '#/components/responses/Templates'
-        '400':
-          $ref: '#/components/responses/400badRequest'
-        '401':
-          $ref: '#/components/responses/401unauthorised'
-        '403':
-          $ref: '#/components/responses/403forbidden'
-        '404':
-          $ref: '#/components/responses/404notFound'
-        '415':
-          $ref: '#/components/responses/415unsupportedMediaType'
-        '422':
-          $ref: '#/components/responses/422unprocessibleEntity'
-        '500':
-          $ref: '#/components/responses/500internalServerError'
+          description: OK
+          content:
+            examples:
+              examples:
+                response:
+                  value:
+                    status: '1 to 4 of 4    '
+                    messagetemplates:
+                      - messageTemplateName: Appointment Reminder
+                        messageTemplateDescription: ''
+                        id: F0547F6F2E4839F8
+                        link:
+                          - uri: 'https://api.au.whispir.com/templates/F0547F6F2E4839F8'
+                            rel: self
+                            method: GET
+                      - messageTemplateName: Customer Survey
+                        messageTemplateDescription: ''
+                        id: DDE10AC13FB0E457
+                        link:
+                          - uri: 'https://api.au.whispir.com/templates/DDE10AC13FB0E457'
+                            rel: self
+                            method: GET
+                      - messageTemplateName: Service announcement
+                        messageTemplateDescription: ''
+                        id: 900972D1C916FE84
+                        link:
+                          - uri: 'https://api.au.whispir.com/templates/900972D1C916FE84'
+                            rel: self
+                            method: GET
+                      - messageTemplateName: Shift Opportunity
+                        messageTemplateDescription: ''
+                        id: 9CB9BE20B885542D
+                        link:
+                          - uri: 'https://api.au.whispir.com/templates/9CB9BE20B885542D'
+                            rel: self
+                            method: GET
+                    link: []
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/templates/{templateId}':
@@ -1831,23 +1810,20 @@ paths:
           schema:
             type: string
             example: 321D8505157C5F27
+        - schema:
+            type: string
+            default: application/vnd.whispir.template-v1+json
+          in: header
+          name: Content-Type
+          description: Indicates the resource's media type
+        - schema:
+            type: string
+          in: header
+          name: Content-Length
+          description: 'Indicates the size of the entity body, in bytes'
       responses:
-        '200':
+        '201':
           $ref: '#/components/responses/Template'
-        '400':
-          $ref: '#/components/responses/400badRequest'
-        '401':
-          $ref: '#/components/responses/401unauthorised'
-        '403':
-          $ref: '#/components/responses/403forbidden'
-        '404':
-          $ref: '#/components/responses/404notFound'
-        '415':
-          $ref: '#/components/responses/415unsupportedMediaType'
-        '422':
-          $ref: '#/components/responses/422unprocessibleEntity'
-        '500':
-          $ref: '#/components/responses/500internalServerError'
     put:
       tags:
         - Templates
@@ -1872,25 +1848,11 @@ paths:
           application/vnd.whispir.template-v1+xml:
             schema:
               $ref: '#/components/schemas/template'
-        description: Templates object that needs to be updated Templates
+        description: Templates object that needs to be update Templates
         required: true
       responses:
         '204':
           description: No Content
-        '400':
-          $ref: '#/components/responses/400badRequest'
-        '401':
-          $ref: '#/components/responses/401unauthorised'
-        '403':
-          $ref: '#/components/responses/403forbidden'
-        '404':
-          $ref: '#/components/responses/404notFound'
-        '415':
-          $ref: '#/components/responses/415unsupportedMediaType'
-        '422':
-          $ref: '#/components/responses/422unprocessibleEntity'
-        '500':
-          $ref: '#/components/responses/500internalServerError'
     delete:
       tags:
         - Templates
@@ -1910,20 +1872,6 @@ paths:
       responses:
         '204':
           description: No Content
-        '400':
-          $ref: '#/components/responses/400badRequest'
-        '401':
-          $ref: '#/components/responses/401unauthorised'
-        '403':
-          $ref: '#/components/responses/403forbidden'
-        '404':
-          $ref: '#/components/responses/404notFound'
-        '415':
-          $ref: '#/components/responses/415unsupportedMediaType'
-        '422':
-          $ref: '#/components/responses/422unprocessibleEntity'
-        '500':
-          $ref: '#/components/responses/500internalServerError'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/responserules':
@@ -4035,11 +3983,6 @@ components:
           schema:
             $ref: '#/components/schemas/event'
       description: events object that needs to be create events
-    template:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/template'
   securitySchemes:
     BasicAuth:
       type: http
@@ -4499,52 +4442,22 @@ components:
           derefUri: W3sNCiAiZnVsbG5hbWUiOiAiRnJhbmNvIEhpbWJvbGkiLA0KICJlbWFpbCI6ICJmdHJpbWJvbGlAZ21haWwuY29tIiwNCiAibW9iaWxlIjogIjA0MTA1MDkwMDEiLA0KICJzdHJlZXRhZGRyZXNzIjogIjEyMyBBdWJ1cm4gUmQiLA0KICJzdWJ1cmIiOiAiSGF3dGhvcm4iLA0KICJSZWZlcmVuY2UiOiAiWHByZXNzIE1haWwiLA0KICJNc2dEYXRhIiA6IHsgDQoJIlBPQkRldGFpbCI6IHsNCgkJIkRhdGVBbmRUaW1lIiA6ICIwOS1TZXAtMjAxNSAxMjoxNSBQTSIsDQoJCSJNZXNzYWdlIiA6ICJQbGVhc2UgbGV0IHVzIGtub3cgaWYgdGhlIHRpbWUgc2xvdCBpcyBhY2NlcHRhYmxlLiBSZXNwb25kIHdpdGggYSAnTm8nIHRvIGdldCBhbHRlcm5hdGl2ZSB0aW1lIHNsb3QiDQoJfQ0KICB9DQp9LA0Kew0KICJmdWxsbmFtZSI6ICJKb3JkYW4gV2luZHNvciIsDQogImVtYWlsIjogImp3aW5kc29yQHlhaG9vLmNvbSIsDQogIm1vYmlsZSI6ICIwNDEwNTA5MDAyIiwNCiAic3RyZWV0YWRkcmVzcyI6ICIzNjAgV2Fsc2ggUmQiLA0KICJzdWJ1cmIiOiAiTm9ydGggTWVsYm91cm5lIiwNCiAiUmVmZXJlbmNlIjogIlhwcmVzcyBNYWlsIiwNCiAiTXNnRGF0YSIgOiB7IA0KCSJQT0JEZXRhaWwiOiB7DQoJCSJEYXRlQW5kVGltZSIgOiAiMDktU2VwLTIwMTUgMTI6MzAgUE0iLA0KCQkiTWVzc2FnZSIgOiAiUGxlYXNlIGxldCB1cyBrbm93IGlmIHRoZSB0aW1lIHNsb3QgaXMgYWNjZXB0YWJsZS4gUmVzcG9uZCB3aXRoIGEgJ05vJyB0byBnZXQgYWx0ZXJuYXRpdmUgdGltZSBzbG90Ig0KCX0NCiAgfQ0KfV0
     template:
       type: object
-      xml:
-        name: template
-        prefix: ns3
-      x-tags:
-        - Templates
-      title: Template
-      x-examples:
-        Template:
-          messageTemplateName: Sample SMS Template
-          messageTemplateDescription: Template to provide an example on whispir.io
-          responseTemplateId: string
-          subject: Test SMS Message
-          body: This is the body of my test SMS message
-          email:
-            body: This is the body of my test Email message
-            footer: This is the footer of my message (generally where a signature would go)
-            type: text/plain
-          voice:
-            header: 'This is the introduction, read out prior to any key press'
-            body: 'This is the body of the voice call, read out after the key press'
-            type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
-          web:
-            body: This is the content of my web publishing or Rich Push Message
-            type: text/plain
-          social:
-            social:
-              - id: social_long
-                body: Facebook Content.
-                type: text/plain
-          type: defaultNoReply
-          features:
-            pushOptions:
-              notifications: enabled
-              escalationMins: 3
-      description: ''
+      required:
+        - messageTemplateName
+        - subject
+        - body
+        - email
+        - voice
+        - web
       properties:
         messageTemplateName:
           type: string
           description: Specifies the name of the message template to be used within message requests.
           example: Sample SMS Template
-          maxLength: 50
         messageTemplateDescription:
           type: string
           description: Specifies the description of the message template for others to understand its purpose.
           example: Template to provide an example on whispir.io
-          maxLength: 250
         responseTemplateId:
           type: string
           description: Specifies the ID of the Response Rule that should be associated with this Message Template.
@@ -4553,15 +4466,10 @@ components:
           type: string
           description: 'Specifies the first line of the SMS message or Voice call, and the subject of the Email message.'
           example: Test SMS Message
-          maxLength: 1570
         body:
           type: string
           description: Specifies the content of the SMS message.
           example: This is the body of my test SMS message
-          maxLength: 1570
-        responseTemplateId:
-          type: string
-          description: Specifies the ID of the Response Rule that should be associated with this Message Template.
         email:
           $ref: '#/components/schemas/email'
         voice:
@@ -4576,10 +4484,12 @@ components:
           example: defaultNoReply
         features:
           $ref: '#/components/schemas/features'
-      required:
-        - messageTemplateName
-        - subject
-        - body
+      xml:
+        name: template
+        prefix: ns3
+      x-tags:
+        - Templates
+      title: Template
     responseTemplatePattern:
       type: object
       properties:
@@ -5190,63 +5100,6 @@ components:
       xml:
         name: fieldMapping
       title: Field Mapping
-    link:
-      title: link
-      type: object
-      properties:
-        uri:
-          type: string
-          example: 'https://api.ap1.whispir.com/workspaces/{workspaceId}/{resourceName}/{resourceId}'
-        rel:
-          type: string
-          example: self
-        method:
-          type: string
-          enum:
-            - GET
-            - POST
-            - DELETE
-            - PUT
-        host:
-          type: string
-          example: api.ap1.whispir.com
-        port:
-          type: integer
-          example: -1
-    dlr:
-      description: Has a fixed object structure and is used for Whispir Internal tracking purposes and has no related value to the Customer.
-      type: object
-      x-examples:
-        example-1:
-          period: ''
-          rule: ''
-          type: ''
-          publishToWeb: false
-          expiryDay: 0
-          expiryHour: 0
-          expiryMin: 0
-          feedIds: ''
-          bool: false
-      properties:
-        period:
-          type: string
-        rule:
-          type: string
-        type:
-          type: string
-        publishToWeb:
-          type: boolean
-        expiryDay:
-          type: number
-        expiryHour:
-          type: number
-        expiryMin:
-          type: number
-        feedIds:
-          type: string
-        bool:
-          type: boolean
-      x-internal: true
     attachment:
       type: object
       description: |-
@@ -5292,23 +5145,26 @@ components:
         example: 9A4C5521FFC7B15B
       description: The identifier for the workspace.
       required: true
+    limit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: number
+        default: 20
+        maximum: 20
+      description: The number of records to be returned.
+    offset:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: number
+        default: 0
+      description: The record number to start returning from.
   responses:
-    500internalServerError:
-      description: 500 Internal Server Error
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              message:
-                type: string
-                example: INTERNAL SERVER ERROR
-          examples:
-            500 Internal Server Error:
-              value:
-                message: INTERNAL SERVER ERROR
     Template:
-      description: This is the response object returned for creating and retrieving a message template
+      description: Example Template response object
       content:
         application/json:
           schema:
@@ -5316,8 +5172,8 @@ components:
             type: object
             x-examples:
               example-1:
-                messageTemplateName: Sample SMS Template
-                messageTemplateDescription: Template to provide an example on whispir.io
+                messageTemplateName: Sample SMS Template with tags
+                messageTemplateDescription: Template to provide an example on whispir.io no.1
                 subject: Test SMS Message
                 tags: ''
                 dlr:
@@ -5346,19 +5202,19 @@ components:
                   footer: ''
                   other: ''
                 responseTemplateId: 7D9A8AAA54747711
-                id: D358B574E4FC18DB
+                id: 3148356543415EE7
                 link:
-                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/D358B574E4FC18DB'
+                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
                     rel: self
                     method: GET
                     host: api.au.whispir.com
                     port: -1
-                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/D358B574E4FC18DB'
+                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
                     rel: deleteTemplate
                     method: DELETE
                     host: api.au.whispir.com
                     port: -1
-                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/D358B574E4FC18DB'
+                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
                     rel: updateTemplate
                     method: PUT
                     host: api.au.whispir.com
@@ -5367,27 +5223,61 @@ components:
               messageTemplateName:
                 type: string
                 minLength: 1
-                description: Specifies the name of the message template to be used within message requests.
+                description: Specifies the name of the message template to be stored
               messageTemplateDescription:
                 type: string
                 minLength: 1
-                description: Specifies the description of the message template for others to understand its purpose.
+                description: 'Specifies the description of the message template, so that others can understand its purpose'
               subject:
                 type: string
                 minLength: 1
-                description: 'Specifies the first line of the SMS message or Voice call, and the subject of the Email message.'
+                description: Specifies the subject of the email message
               tags:
                 type: string
-                description: Metadata to identify related resources together for easy group viewing from the UI
+                description: Information which helps to label related message templates together
               dlr:
-                $ref: '#/components/schemas/dlr'
+                type: object
+                description: dlr stands for "delivery receipt" which has a fixed object structure and is used for Whispir internal tracking purposes.
+                properties:
+                  period:
+                    type: string
+                  rule:
+                    type: string
+                  type:
+                    type: string
+                  publishToWeb:
+                    type: boolean
+                    default: false
+                  expiryDay:
+                    type: number
+                  expiryHour:
+                    type: number
+                  expiryMin:
+                    type: number
+                  feedIds:
+                    type: string
+                  bool:
+                    type: boolean
+                    default: false
               body:
                 type: string
-                description: Specifies the content of the SMS message.
+                minLength: 1
+                description: |-
+                  The SMS body.
+
+                  The maximum payload size rule applies.
+
+                  IMPORTANT: The total SMS length is 1570 characters for english text and 800 when UTF-8 characters are used (primarily non-english)
+
+                  The 1570 length is a combination of subject and body.
+                maxLength: 1570
               type:
                 type: string
                 minLength: 1
                 description: Allows the user to modify the message behaviour for replies and DLRs (delivery receipts)
+                enum:
+                  - defaultNoReply
+                  - noDlr
                 example: defaultNoReply
               email:
                 $ref: '#/components/schemas/email'
@@ -5398,50 +5288,71 @@ components:
               responseTemplateId:
                 type: string
                 minLength: 1
-                description: Specifies the ID of the Response Rule that should be associated with this Message Template.
+                example: 7D9A8AAA54747711
+                description: Specifies the ID of the Response Rule that should be associated with this message template. Do not insert in the payload when unused
               id:
                 type: string
                 minLength: 1
-                description: The given identifier of the message template object
+                description: Specifies the ID of the template that can be referenced to use it
+                example: 3148356543415EE7
+                readOnly: true
               link:
                 type: array
                 uniqueItems: true
-                minItems: 1
-                description: Describes the available API endpoints for the given resource
+                description: Provides a list of URLs that can be used to manipulate or access the message template. This following attribute may return an empty array.
+                minItems: 0
                 items:
-                  $ref: '#/components/schemas/link'
+                  type: object
+                  description: Provides a list of URLs that can be used to manipulate or access the message template. This following attribute may return an empty array when there are no available URLs
+                  properties:
+                    uri:
+                      type: string
+                      minLength: 1
+                      format: uri
+                      example: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
+                      description: The link to access the message template
+                      readOnly: true
+                    rel:
+                      type: string
+                      minLength: 1
+                      description: The descriptor for what the link will do
+                      default: self
+                      readOnly: true
+                    method:
+                      type: string
+                      minLength: 1
+                      description: The HTTP method to use with this particular link
+                      enum:
+                        - GET
+                        - DELETE
+                        - PUT
+                      example: GET
+                      readOnly: true
+                    host:
+                      type: string
+                      minLength: 1
+                      description: Host of the endpoint
+                      readOnly: true
+                    port:
+                      type: number
+                      description: Port number of the endpoint
+                      default: -1
+                      readOnly: true
+            required:
+              - messageTemplateName
+              - subject
+              - body
+              - type
+              - responseTemplateId
+              - id
           examples:
-            The Message Template:
+            Template Response Object:
               value:
-                messageTemplateName: Sample SMS Template
-                messageTemplateDescription: Template to provide an example on whispir.io
-                subject: Test SMS Message
-                body: This is the body of my test SMS message
-                responseTemplateId: string
-                email:
-                  body: This is the body of my test Email message
-                  footer: This is the footer of my message (generally where a signature would go)
-                  type: text/plain
-                voice:
-                  header: 'This is the introduction, read out prior to any key press'
-                  body: 'This is the body of the voice call, read out after the key press'
-                  type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
-                web:
-                  body: This is the content of my web publishing or Rich Push Message
-                  type: text/plain
-                social:
-                  social:
-                    - id: social_long
-                      body: Facebook Content.
-                      type: text/plain
-                type: defaultNoReply
-                features:
-                  pushOptions:
-                    notifications: enabled
-                    escalationMins: 3
-                id: C23D6E2DD3D251BF
+                messageTemplateName: Example template name
+                messageTemplateDescription: template description
+                subject: template subject
                 tags: ''
-                dir:
+                dlr:
                   period: ''
                   rule: ''
                   type: ''
@@ -5451,298 +5362,37 @@ components:
                   expiryMin: 0
                   feedIds: ''
                   bool: false
+                body: template message body
+                type: defaultNoReply
+                email:
+                  body: This is the body of my email message.
+                  footer: This is the footer of my message.
+                  type: text/plain
+                  resources:
+                    attachments:
+                      - attachmentName: photo.jpeg
+                        derefUri: iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==
+                        attachmentDesc: My photo
+                web:
+                  body: This is the content of my web publishing or Rich Push Message
+                  type: text/plain
+                voice:
+                  header: 'This is the introduction, read out to the recipient prior to any key press.'
+                  body: 'This is the body of the voice call, read out after the key press'
+                  type: 'Pin:7171,ConfCall:1800123123,ConfAccountNo:098711234,ConfPinNo:8181,ConfModPinNo:4242'
+                  resources:
+                    attachment:
+                      - attachmentName: photo.jpeg
+                        derefUri: iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==
+                        attachmentDesc: My photo
+                responseTemplateId: 7D9A8AAA54747711
+                id: 3148356543415EE7
                 link:
-                  - uri: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
+                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
                     rel: self
                     method: GET
-                    host: api.ap1.whispir.com
+                    host: string
                     port: -1
-                  - uri: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
-                    rel: updateTemplate
-                    method: PUT
-                    host: api.ap1.whispir.com
-                    port: -1
-                  - uri: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
-                    rel: deleteTemplate
-                    method: DELETE
-                    host: api.ap1.whispir.com
-                    port: -1
-    400badRequest:
-      description: Example response of a 400 bad request error
-      content:
-        application/json:
-          schema:
-            description: ''
-            type: object
-            x-examples:
-              example-1:
-                errorSummary: Your request was malformed and could not be processed by the server. Please try again
-                errorText: Bad Request
-                errorDetail: 'java.io.EOFException: No content to map to Object due to end of input'
-            properties:
-              errorSummary:
-                type: string
-                minLength: 1
-                example: Your request was malformed and could not be processed by the server. Please try again
-              errorText:
-                type: string
-                minLength: 1
-                example: Bad Request
-              errorDetail:
-                type: string
-                minLength: 1
-                example: 'java.io.EOFException: No content to map to Object due to end of input'
-              link:
-                type: array
-                items: {}
-          examples:
-            400 Bad Request:
-              value:
-                errorSummary: Your request was malformed and could not be processed by the server. Please try again
-                errorText: Bad Request
-                errorDetail: 'java.io.EOFException: No content to map to Object due to end of input'
-                link: []
-    401unauthorised:
-      description: 401 Unauthorized Error
-      content:
-        application/json:
-          schema:
-            description: ''
-            type: object
-            x-examples:
-              example-1:
-                errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
-                errorText: Unauthorized
-                errorDetail: ''
-                link: []
-            properties:
-              errorSummary:
-                type: string
-                minLength: 1
-                example: Your username and password combination was incorrect. Please check your authentication details and try again
-              errorText:
-                type: string
-                minLength: 1
-                example: Unauthorized
-              errorDetail:
-                type: string
-              link:
-                type: array
-                items: {}
-          examples:
-            401 Unauthorized Error:
-              value:
-                errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
-                errorText: Unauthorized
-                errorDetail: ''
-                link: []
-    403forbidden:
-      description: 403 Forbidden Error
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              message:
-                type: string
-                example: Forbidden
-          examples:
-            403 Forbidden:
-              value:
-                message: Forbidden
-    404notFound:
-      description: 404 Not Found Error
-      content:
-        application/json:
-          schema:
-            description: ''
-            type: object
-            x-examples:
-              example-1:
-                errorSummary: The resource that you have requested does not exist. Please check the identifier and try again
-                errorText: Not Found
-                errorDetail: ''
-                link: []
-            properties:
-              errorSummary:
-                type: string
-                minLength: 1
-                example: The resource that you have requested does not exist. Please check the identifier and try again
-              errorText:
-                type: string
-                minLength: 1
-                example: Not Found
-              errorDetail:
-                type: string
-              link:
-                type: array
-                items: {}
-          examples:
-            example-1:
-              value:
-                errorSummary: The resource that you have requested does not exist. Please check the identifier and try again
-                errorText: Not Found
-                errorDetail: ''
-                link: []
-    415unsupportedMediaType:
-      description: 415 Unsupported Media Type
-      content:
-        application/json:
-          schema:
-            description: ''
-            type: object
-            x-examples:
-              example-1:
-                errorSummary: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
-                errorText: Unsupported Media Type
-                errorDetail: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
-                link: []
-            properties:
-              errorSummary:
-                type: string
-                minLength: 1
-                example: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
-              errorText:
-                type: string
-                minLength: 1
-                example: Unsupported Media Type
-              errorDetail:
-                type: string
-                minLength: 1
-                example: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
-              link:
-                type: array
-                items: {}
-          examples:
-            415 Unsupported Media Type:
-              value:
-                errorSummary: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
-                errorText: Unsupported Media Type
-                errorDetail: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
-                link: []
-    422unprocessibleEntity:
-      description: 422 Unprocessible Entitity
-      content:
-        application/json:
-          schema:
-            description: ''
-            type: object
-            x-examples:
-              example-1:
-                errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
-                errorText: |
-                  A Template name already exists in the current Workspace, please select another name and try again.
-                errorDetail: ''
-                link: []
-            properties:
-              errorSummary:
-                type: string
-                minLength: 1
-                example: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
-              errorText:
-                type: string
-                minLength: 1
-                example: 'A Template name already exists in the current Workspace, please select another name and try again.\n'
-              errorDetail:
-                type: string
-              link:
-                type: array
-                items: {}
-          examples:
-            422 Unprocessable Entity:
-              value:
-                errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
-                errorText: 'A Template name already exists in the current Workspace, please select another name and try again.\n'
-                errorDetail: ''
-                link: []
-    Templates:
-      description: Response object which returns a list of message templates
-      content:
-        application/json:
-          schema:
-            description: ''
-            type: object
-            x-examples:
-              example-1:
-                status: '1 to 1 of 1    '
-                messagetemplates:
-                  - messageTemplateName: Sample SMS Template no.2
-                    messageTemplateDescription: Template to provide an example on whispir.io no.2
-                    id: F79CF32E37767CFC
-                    link:
-                      - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/F79CF32E37767CFC'
-                        rel: self
-                        method: GET
-                        host: api.au.whispir.com
-                        port: -1
-                link: []
-            properties:
-              status:
-                type: string
-                minLength: 1
-                description: Describes the number of records fetched
-                example: 1 to 1 of 1
-              messagetemplates:
-                type: array
-                uniqueItems: true
-                minItems: 0
-                description: Contains a list of all the message templates. This following attributed will be omitted when there are no records to be fetched
-                items:
-                  type: object
-                  properties:
-                    messageTemplateName:
-                      type: string
-                      description: Specifies the name of the message template to be used within message requests.
-                      example: Sample Template Name
-                    messageTemplateDescription:
-                      type: string
-                      description: Specifies the description of the message template for others to understand its purpose.
-                      example: Template to provide an example on whispir.io
-                    id:
-                      type: string
-                      example: B99F5F0A95F35E57
-                    link:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/link'
-              link:
-                type: array
-                items:
-                  $ref: '#/components/schemas/link'
-          examples:
-            A List of Message Templates:
-              value:
-                status: string
-                messagetemplates:
-                  - messageTemplateName: string
-                    messageTemplateDescription: string
-                    id: string
-                    link:
-                      - uri: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
-                        rel: self
-                        method: GET
-                        host: api.ap1.whispir.com
-                        port: -1
-                link: []
-  examples: {}
-    limit:
-      name: limit
-      in: query
-      required: false
-      schema:
-        type: number
-        default: 20
-        maximum: 20
-      description: The number of records to be returned.
-    offset:
-      name: offset
-      in: query
-      required: false
-      schema:
-        type: number
-        default: 0
-      description: The record number to start returning from.
-  responses: {}
   headers:
     Access-Control-Allow-Origin:
       description: Origins allowed to perform cross-origin requests.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1009,14 +1009,43 @@ paths:
           application/vnd.whispir.template-v1+json:
             schema:
               $ref: '#/components/schemas/template'
+            examples:
+              The Template Object:
+                value:
+                  messageTemplateName: Sample SMS Template
+                  messageTemplateDescription: Template to provide an example on whispir.io
+                  subject: Test SMS Message
+                  body: This is the body of my test SMS message
+                  responseTemplateId: string
+                  email:
+                    body: This is the body of my test Email message
+                    footer: This is the footer of my message (generally where a signature would go)
+                    type: text/plain
+                  voice:
+                    header: 'This is the introduction, read out prior to any key press'
+                    body: 'This is the body of the voice call, read out after the key press'
+                    type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
+                  web:
+                    body: This is the content of my web publishing or Rich Push Message
+                    type: text/plain
+                  social:
+                    social:
+                      - id: social_long
+                        body: Facebook Content.
+                        type: text/plain
+                  type: defaultNoReply
+                  features:
+                    pushOptions:
+                      notifications: enabled
+                      escalationMins: 3
           application/vnd.whispir.template-v1+xml:
             schema:
               $ref: '#/components/schemas/template'
-        description: Templates object that needs to be create Templates
+        description: The template object
         required: true
       responses:
         '201':
-          description: Created
+          $ref: '#/components/responses/Template'
         '400':
           $ref: '#/components/responses/400badRequest'
         '401':
@@ -1058,6 +1087,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/x-api-key'
       responses:
+        '200':
+          $ref: '#/components/responses/Templates'
         '400':
           $ref: '#/components/responses/400badRequest'
         '401':
@@ -1092,7 +1123,7 @@ paths:
             example: 321D8505157C5F27
       responses:
         '200':
-          $ref: '#/components/responses/template'
+          $ref: '#/components/responses/Template'
         '400':
           $ref: '#/components/responses/400badRequest'
         '401':
@@ -4206,7 +4237,7 @@ components:
       properties:
         uri:
           type: string
-          example: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
+          example: 'https://api.ap1.whispir.com/workspaces/{workspaceId}/{resourceName}/{resourceId}'
         rel:
           type: string
           example: self
@@ -4223,6 +4254,40 @@ components:
         port:
           type: integer
           example: -1
+    dlr:
+      description: Has a fixed object structure and is used for Whispir Internal tracking purposes and has no related value to the Customer.
+      type: object
+      x-examples:
+        example-1:
+          period: ''
+          rule: ''
+          type: ''
+          publishToWeb: false
+          expiryDay: 0
+          expiryHour: 0
+          expiryMin: 0
+          feedIds: ''
+          bool: false
+      properties:
+        period:
+          type: string
+        rule:
+          type: string
+        type:
+          type: string
+        publishToWeb:
+          type: boolean
+        expiryDay:
+          type: number
+        expiryHour:
+          type: number
+        expiryMin:
+          type: number
+        feedIds:
+          type: string
+        bool:
+          type: boolean
+      x-internal: true
   parameters:
     x-api-key:
       name: x-api-key
@@ -4255,14 +4320,111 @@ components:
             500 Internal Server Error:
               value:
                 message: INTERNAL SERVER ERROR
-    template:
-      description: Example response of a template resource
+    Template:
+      description: This is the response object returned for creating and retrieving a message template
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/template'
+            description: ''
+            type: object
+            x-examples:
+              example-1:
+                messageTemplateName: Sample SMS Template
+                messageTemplateDescription: Template to provide an example on whispir.io
+                subject: Test SMS Message
+                tags: ''
+                dlr:
+                  period: ''
+                  rule: ''
+                  type: ''
+                  publishToWeb: false
+                  expiryDay: 0
+                  expiryHour: 0
+                  expiryMin: 0
+                  feedIds: ''
+                  bool: false
+                body: This is the body of my test SMS message
+                type: defaultNoReply
+                email:
+                  type: text/plain
+                  body: This is the body of my test Email message
+                  footer: This is the footer of my message (generally where a signature would go)
+                web:
+                  type: text/plain
+                  body: This is the content of my web publishing or Rich Push Message
+                voice:
+                  type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
+                  header: 'This is the introduction, read out prior to any key press'
+                  body: 'This is the body of the voice call, read out after the key press'
+                  footer: ''
+                  other: ''
+                responseTemplateId: 7D9A8AAA54747711
+                id: D358B574E4FC18DB
+                link:
+                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/D358B574E4FC18DB'
+                    rel: self
+                    method: GET
+                    host: api.au.whispir.com
+                    port: -1
+                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/D358B574E4FC18DB'
+                    rel: deleteTemplate
+                    method: DELETE
+                    host: api.au.whispir.com
+                    port: -1
+                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/D358B574E4FC18DB'
+                    rel: updateTemplate
+                    method: PUT
+                    host: api.au.whispir.com
+                    port: -1
+            properties:
+              messageTemplateName:
+                type: string
+                minLength: 1
+                description: Specifies the name of the message template to be used within message requests.
+              messageTemplateDescription:
+                type: string
+                minLength: 1
+                description: Specifies the description of the message template for others to understand its purpose.
+              subject:
+                type: string
+                minLength: 1
+                description: 'Specifies the first line of the SMS message or Voice call, and the subject of the Email message.'
+              tags:
+                type: string
+                description: Metadata to identify related resources together for easy group viewing from the UI
+              dlr:
+                $ref: '#/components/schemas/dlr'
+              body:
+                type: string
+                description: Specifies the content of the SMS message.
+              type:
+                type: string
+                minLength: 1
+                description: Allows the user to modify the message behaviour for replies and DLRs (delivery receipts)
+                example: defaultNoReply
+              email:
+                $ref: '#/components/schemas/email'
+              web:
+                $ref: '#/components/schemas/web'
+              voice:
+                $ref: '#/components/schemas/voice'
+              responseTemplateId:
+                type: string
+                minLength: 1
+                description: Specifies the ID of the Response Rule that should be associated with this Message Template.
+              id:
+                type: string
+                minLength: 1
+                description: The given identifier of the message template object
+              link:
+                type: array
+                uniqueItems: true
+                minItems: 1
+                description: Describes the available API endpoints for the given resource
+                items:
+                  $ref: '#/components/schemas/link'
           examples:
-            example-1:
+            The Message Template:
               value:
                 messageTemplateName: Sample SMS Template
                 messageTemplateDescription: Template to provide an example on whispir.io
@@ -4505,5 +4667,74 @@ components:
                 errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
                 errorText: 'A Template name already exists in the current Workspace, please select another name and try again.\n'
                 errorDetail: ''
+                link: []
+    Templates:
+      description: Response object which returns a list of message templates
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            x-examples:
+              example-1:
+                status: '1 to 1 of 1    '
+                messagetemplates:
+                  - messageTemplateName: Sample SMS Template no.2
+                    messageTemplateDescription: Template to provide an example on whispir.io no.2
+                    id: F79CF32E37767CFC
+                    link:
+                      - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/F79CF32E37767CFC'
+                        rel: self
+                        method: GET
+                        host: api.au.whispir.com
+                        port: -1
+                link: []
+            properties:
+              status:
+                type: string
+                minLength: 1
+                description: Describes the number of records fetched
+                example: 1 to 1 of 1
+              messagetemplates:
+                type: array
+                uniqueItems: true
+                minItems: 0
+                description: Contains a list of all the message templates. This following attributed will be omitted when there are no records to be fetched
+                items:
+                  type: object
+                  properties:
+                    messageTemplateName:
+                      type: string
+                      description: Specifies the name of the message template to be used within message requests.
+                      example: Sample Template Name
+                    messageTemplateDescription:
+                      type: string
+                      description: Specifies the description of the message template for others to understand its purpose.
+                      example: Template to provide an example on whispir.io
+                    id:
+                      type: string
+                      example: B99F5F0A95F35E57
+                    link:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/link'
+              link:
+                type: array
+                items:
+                  $ref: '#/components/schemas/link'
+          examples:
+            A List of Message Templates:
+              value:
+                status: string
+                messagetemplates:
+                  - messageTemplateName: string
+                    messageTemplateDescription: string
+                    id: string
+                    link:
+                      - uri: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
+                        rel: self
+                        method: GET
+                        host: api.ap1.whispir.com
+                        port: -1
                 link: []
   examples: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5471,6 +5471,179 @@ components:
                     method: GET
                     host: string
                     port: -1
+    400BadRequest:
+      description: 400 Bad Request Error
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            properties:
+              errorSummary:
+                type: string
+                minLength: 1
+              errorText:
+                type: string
+                minLength: 1
+              errorDetail:
+                type: string
+                minLength: 1
+            required:
+              - errorSummary
+              - errorText
+              - errorDetail
+            x-examples:
+              example-1:
+                errorSummary: Your request was malformed and could not be processed by the server. Please try again
+                errorText: Bad Request
+                errorDetail: 'java.io.EOFException: No content to map to Object due to end of input'
+    401Unauthorized:
+      description: 401 Unauthorized Error
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            properties:
+              links: {}
+              errorSummary:
+                type: string
+                minLength: 1
+              errorText:
+                type: string
+                minLength: 1
+              errorDetail:
+                type: string
+            required:
+              - errorSummary
+              - errorText
+              - errorDetail
+            x-examples:
+              example-1:
+                links: null
+                errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
+                errorText: Unauthorized
+                errorDetail: ''
+    403Forbidden:
+      description: 403 Forbidden Error
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            properties:
+              message:
+                type: string
+                minLength: 1
+            required:
+              - message
+            x-examples:
+              example-1:
+                message: Forbidden
+    404NotFound:
+      description: 404 Not found Error
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            properties:
+              errorSummary:
+                type: string
+                minLength: 1
+              errorText:
+                type: string
+                minLength: 1
+              errorDetail:
+                type: string
+              link:
+                type: array
+                items:
+                  required: []
+                  properties: {}
+            required:
+              - errorSummary
+              - errorText
+              - errorDetail
+              - link
+            x-examples:
+              example-1:
+                errorSummary: 'The resource that you have requested does not exist. Please check the identifier and try again '
+                errorText: Not Found
+                errorDetail: ''
+                link: []
+    415UnsupportedMediaType:
+      description: 415 Unsupported Media Type Error
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            properties:
+              errorSummary:
+                type: string
+                minLength: 1
+              errorText:
+                type: string
+                minLength: 1
+              errorDetail:
+                type: string
+                minLength: 1
+            required:
+              - errorSummary
+              - errorText
+              - errorDetail
+            x-examples:
+              example-1:
+                errorSummary: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
+                errorText: Unsupported Media Type
+                errorDetail: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
+    422UnprocessibleEntity:
+      description: 422 Unprocessible Entity Error
+      content:
+        application/json:
+          schema:
+            description: ''
+            type: object
+            properties:
+              errorSummary:
+                type: string
+                minLength: 1
+              errorText:
+                type: string
+                minLength: 1
+              errorDetail:
+                type: string
+              link:
+                type: array
+                items:
+                  required: []
+                  properties: {}
+            required:
+              - errorSummary
+              - errorText
+              - errorDetail
+              - link
+            x-examples:
+              example-1:
+                errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
+                errorText: |
+                  A Template name already exists in the current Workspace, please select another name and try again.
+                errorDetail: ''
+                link: []
+    500InternalServerError:
+      description: 500 Internal Server Error
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            example-1:
+              value:
+                message: Internal Server Error
   headers:
     Access-Control-Allow-Origin:
       description: Origins allowed to perform cross-origin requests.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -243,7 +243,7 @@ paths:
                 description: ''
                 type: object
                 x-examples:
-                  example-1:
+                  Example:
                     messages:
                       - subject: Test Message
                         repetitionCount: 0
@@ -788,7 +788,7 @@ paths:
               schema:
                 description: ''
                 x-examples:
-                  example-1:
+                  Example:
                     messageresponses:
                       - percentageTotal: 50%
                         responseCount: '1'
@@ -1233,7 +1233,7 @@ paths:
                 description: Returns a list of templates
                 type: object
                 x-examples:
-                  example-1:
+                  Example:
                     status: '1 to 1 of 1    '
                     messagetemplates:
                       - messageTemplateName: Sample SMS Template with tags
@@ -3399,7 +3399,7 @@ paths:
                 description: ''
                 type: object
                 x-examples:
-                  example-1:
+                  Example:
                     token: your-generated-bearer-token
                     link: []
                 properties:
@@ -4633,7 +4633,7 @@ components:
           email: me@example.com
           callbacks:
             reply: enabled
-        example-1:
+        Example:
           name: Undeliverable Message
           url: 'https://example.com/callback'
           auth:
@@ -5583,13 +5583,13 @@ components:
       description: The record number to start returning from.
   responses:
     Template:
-      description: Example Template response object
+      description: Template endpoint response.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/template'
           examples:
-            Template object:
+            Example:
               value:
                 messageTemplateName: Sample SMS Template
                 messageTemplateDescription: Template to provide an example on whispir.io
@@ -5660,7 +5660,7 @@ components:
             description: ''
             type: object
             x-examples:
-              example-1:
+              Example:
                 errorSummary: Your request was malformed and could not be processed by the server. Please try again
                 errorText: Bad Request
                 errorDetail: 'java.io.EOFException: No content to map to Object due to end of input'
@@ -5682,7 +5682,7 @@ components:
               - errorText
               - errorDetail
           examples:
-            example-1:
+            Example:
               value:
                 errorSummary: Your request was malformed and could not be processed by the server. Please try again
                 errorText: Bad Request
@@ -5695,14 +5695,9 @@ components:
           schema:
             description: ''
             type: object
-            x-examples:
-              example-1:
-                links: null
-                errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
-                errorText: Unauthorized
-                errorDetail: ''
             properties:
-              links: {}
+              links:
+                $ref: '#/components/schemas/link'
               errorSummary:
                 type: string
                 minLength: 1
@@ -5718,7 +5713,7 @@ components:
               - errorText
               - errorDetail
           examples:
-            example-1:
+            Example:
               value:
                 links: []
                 errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
@@ -5732,9 +5727,6 @@ components:
           schema:
             description: ''
             type: object
-            x-examples:
-              example-1:
-                message: Forbidden
             properties:
               message:
                 type: string
@@ -5743,7 +5735,7 @@ components:
             required:
               - message
           examples:
-            example-1:
+            Example:
               value:
                 message: Forbidden
       headers: {}
@@ -5754,12 +5746,6 @@ components:
           schema:
             description: ''
             type: object
-            x-examples:
-              example-1:
-                errorSummary: 'The resource that you have requested does not exist. Please check the identifier and try again '
-                errorText: Not Found
-                errorDetail: ''
-                link: []
             properties:
               errorSummary:
                 type: string
@@ -5772,11 +5758,9 @@ components:
               errorDetail:
                 type: string
               link:
-                type: array
-                items:
-                  type: object
+                $ref: '#/components/schemas/link'
           examples:
-            example-1:
+            Example:
               value:
                 errorSummary: The resource that you have requested does not exist. Please check the identifier and try again
                 errorText: Not Found
@@ -5789,11 +5773,6 @@ components:
           schema:
             description: ''
             type: object
-            x-examples:
-              example-1:
-                errorSummary: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
-                errorText: Unsupported Media Type
-                errorDetail: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
             properties:
               errorSummary:
                 type: string
@@ -5808,7 +5787,7 @@ components:
                 minLength: 1
                 example: 'javax.ws.rs.NotSupportedException: Cannot consume content type'
           examples:
-            example-1:
+            Example:
               value:
                 errorSummary: 'The media type you have supplied in the request does not match any of the available on the server. Please check the documentation for the correct media-type definitions, or contact support@whispir.com to determine what media-type you should be using'
                 errorText: Unsupported Media Type
@@ -5820,13 +5799,6 @@ components:
           schema:
             description: ''
             type: object
-            x-examples:
-              example-1:
-                errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
-                errorText: |
-                  A Template name already exists in the current Workspace, please select another name and try again.
-                errorDetail: ''
-                link: []
             properties:
               errorSummary:
                 type: string
@@ -5839,11 +5811,9 @@ components:
               errorDetail:
                 type: string
               link:
-                type: array
-                items:
-                  type: object
+                $ref: '#/components/schemas/link'
           examples:
-            example-1:
+            Example:
               value:
                 errorSummary: 'Your request did not contain all of the information required to perform this method. Please check your request for the required fields to be passed in and try again. Alternatively, contact your administrator or support@whispir.com for more information'
                 errorText: |
@@ -5861,7 +5831,7 @@ components:
                 type: string
                 example: Internal Server Error
           examples:
-            example-1:
+            Example:
               value:
                 message: Internal Server Error
   headers:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1869,10 +1869,31 @@ paths:
                   - status
                   - messagetemplates
                   - link
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                default: application/vnd.whispir.template-v1+xml
+                enum:
+                  - application/vnd.whispir.template-v1+xml
+                  - application/vnd.whispir.template-v1+json
+              description: Indicates the resource's media type
+            Content-Length:
+              $ref: '#/components/headers/Content-Length'
+            Access-Control-Allow-Origin:
+              $ref: '#/components/headers/Access-Control-Allow-Origin'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
         '401':
           $ref: '#/components/responses/401Unauthorized'
         '403':
           $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
         '500':
           $ref: '#/components/responses/500InternalServerError'
     parameters:
@@ -4567,48 +4588,6 @@ components:
           derefUri: W3sNCiAiZnVsbG5hbWUiOiAiRnJhbmNvIEhpbWJvbGkiLA0KICJlbWFpbCI6ICJmdHJpbWJvbGlAZ21haWwuY29tIiwNCiAibW9iaWxlIjogIjA0MTA1MDkwMDEiLA0KICJzdHJlZXRhZGRyZXNzIjogIjEyMyBBdWJ1cm4gUmQiLA0KICJzdWJ1cmIiOiAiSGF3dGhvcm4iLA0KICJSZWZlcmVuY2UiOiAiWHByZXNzIE1haWwiLA0KICJNc2dEYXRhIiA6IHsgDQoJIlBPQkRldGFpbCI6IHsNCgkJIkRhdGVBbmRUaW1lIiA6ICIwOS1TZXAtMjAxNSAxMjoxNSBQTSIsDQoJCSJNZXNzYWdlIiA6ICJQbGVhc2UgbGV0IHVzIGtub3cgaWYgdGhlIHRpbWUgc2xvdCBpcyBhY2NlcHRhYmxlLiBSZXNwb25kIHdpdGggYSAnTm8nIHRvIGdldCBhbHRlcm5hdGl2ZSB0aW1lIHNsb3QiDQoJfQ0KICB9DQp9LA0Kew0KICJmdWxsbmFtZSI6ICJKb3JkYW4gV2luZHNvciIsDQogImVtYWlsIjogImp3aW5kc29yQHlhaG9vLmNvbSIsDQogIm1vYmlsZSI6ICIwNDEwNTA5MDAyIiwNCiAic3RyZWV0YWRkcmVzcyI6ICIzNjAgV2Fsc2ggUmQiLA0KICJzdWJ1cmIiOiAiTm9ydGggTWVsYm91cm5lIiwNCiAiUmVmZXJlbmNlIjogIlhwcmVzcyBNYWlsIiwNCiAiTXNnRGF0YSIgOiB7IA0KCSJQT0JEZXRhaWwiOiB7DQoJCSJEYXRlQW5kVGltZSIgOiAiMDktU2VwLTIwMTUgMTI6MzAgUE0iLA0KCQkiTWVzc2FnZSIgOiAiUGxlYXNlIGxldCB1cyBrbm93IGlmIHRoZSB0aW1lIHNsb3QgaXMgYWNjZXB0YWJsZS4gUmVzcG9uZCB3aXRoIGEgJ05vJyB0byBnZXQgYWx0ZXJuYXRpdmUgdGltZSBzbG90Ig0KCX0NCiAgfQ0KfV0
     template:
       type: object
-      required:
-        - messageTemplateName
-        - subject
-        - body
-        - email
-        - voice
-        - web
-      properties:
-        messageTemplateName:
-          type: string
-          description: Specifies the name of the message template to be used within message requests.
-          example: Sample SMS Template
-        messageTemplateDescription:
-          type: string
-          description: Specifies the description of the message template for others to understand its purpose.
-          example: Template to provide an example on whispir.io
-        responseTemplateId:
-          type: string
-          description: Specifies the ID of the Response Rule that should be associated with this Message Template.
-          example: responseTemplateId
-        subject:
-          type: string
-          description: 'Specifies the first line of the SMS message or Voice call, and the subject of the Email message.'
-          example: Test SMS Message
-        body:
-          type: string
-          description: Specifies the content of the SMS message.
-          example: This is the body of my test SMS message
-        email:
-          $ref: '#/components/schemas/email'
-        voice:
-          $ref: '#/components/schemas/voice'
-        web:
-          $ref: '#/components/schemas/web'
-        social:
-          $ref: '#/components/schemas/social'
-        type:
-          type: string
-          description: Allows the user to modify the message behaviour for replies and DLRs (delivery receipts)
-          example: defaultNoReply
-        features:
-          $ref: '#/components/schemas/features'
       xml:
         name: template
         prefix: ns3
@@ -4655,6 +4634,167 @@ components:
               notifications: enabled
               escalationMins: '3'
               appId: appId
+          dlr:
+            period: string
+            publishToWeb: false
+            rule: string
+            expiryDay: 0
+            expiryHour: 0
+            expiryMin: 0
+            feedIds: string
+            bool: false
+            type: string
+          link:
+            - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
+              rel: self
+              method: GET
+              host: api.au.whispir.com
+              port: -1
+          tags: string
+      properties:
+        messageTemplateName:
+          type: string
+          description: Specifies the name of the message template to be used within message requests.
+          example: Sample SMS Template
+          readOnly: true
+        messageTemplateDescription:
+          type: string
+          description: Specifies the description of the message template for others to understand its purpose.
+          example: Template to provide an example on whispir.io
+        responseTemplateId:
+          type: string
+          description: Specifies the ID of the Response Rule that should be associated with this Message Template.
+          example: responseTemplateId
+        subject:
+          type: string
+          description: 'Specifies the first line of the SMS message or Voice call, and the subject of the Email message.'
+          example: Test SMS Message
+        body:
+          type: string
+          description: Specifies the content of the SMS message.
+          example: This is the body of my test SMS message
+        email:
+          $ref: '#/components/schemas/email'
+        voice:
+          $ref: '#/components/schemas/voice'
+        web:
+          $ref: '#/components/schemas/web'
+        social:
+          $ref: '#/components/schemas/social'
+        type:
+          type: string
+          description: Allows the user to modify the message behaviour for replies and DLRs (delivery receipts)
+          example: defaultNoReply
+        features:
+          $ref: '#/components/schemas/features'
+        dlr:
+          type: object
+          description: dlr stands for "delivery receipt" which has a fixed object structure and is used for Whispir internal tracking purposes.
+          properties:
+            period:
+              type: string
+              description: period of dlr
+              example: no example
+              readOnly: true
+            publishToWeb:
+              type: string
+              default: 'false'
+              description: publish to web flag
+              example: 'false'
+              readOnly: true
+            rule:
+              type: string
+              description: dlr rule
+              example: no example
+              readOnly: true
+            expiryDay:
+              type: number
+              default: 0
+              description: expiry duration in day
+              example: 1
+              readOnly: true
+            expiryHour:
+              type: number
+              default: 0
+              description: expiry duration in hour
+              example: 1
+              readOnly: true
+            expiryMin:
+              type: number
+              default: 0
+              description: expiry duration in minutes
+              example: 1
+              readOnly: true
+            feedIds:
+              type: string
+              description: Specifies the id of the feed
+              example: no example
+              readOnly: true
+            bool:
+              type: string
+              default: 'false'
+              example: 'false'
+              description: boolean
+            type:
+              type: string
+              description: Allows the user to modify the message behaviour for replies and DLRs (delivery receipts)
+              example: no example
+              readOnly: true
+          readOnly: true
+        link:
+          type: array
+          description: Provides a list of URLs that can be used to manipulate or access the message template. This following attribute may return an empty array.
+          items:
+            type: object
+            properties:
+              uri:
+                type: string
+                description: The link to access the message template
+                example: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
+                readOnly: true
+              rel:
+                type: string
+                description: The descriptor for what the link will do
+                default: self
+                example: self
+                readOnly: true
+              method:
+                type: string
+                description: The HTTP method to use with this particular link
+                enum:
+                  - GET
+                  - PUT
+                  - DELETE
+                example: GET
+                readOnly: true
+              host:
+                type: string
+                description: Host of the endpoint
+                example: api.au.whispir.com
+                readOnly: true
+              port:
+                type: number
+                description: Port number of the endpoint
+                default: -1
+                example: -1
+                readOnly: true
+            readOnly: true
+          readOnly: true
+        tags:
+          type: string
+          description: Information which helps to label related message templates together
+          example: internal
+          readOnly: true
+        id:
+          type: string
+          example: 7DB65E1D8853D1C8
+          description: specifies the id of the message template
+          default: 7DB65E1D8853D1C8
+          readOnly: true
+      required:
+        - messageTemplateName
+        - subject
+        - body
     responseTemplatePattern:
       type: object
       properties:
@@ -5333,212 +5473,15 @@ components:
       content:
         application/json:
           schema:
-            description: This is the shape of a template response
-            type: object
-            x-examples:
-              example-1:
-                messageTemplateName: Sample SMS Template with tags
-                messageTemplateDescription: Template to provide an example on whispir.io no.1
-                subject: Test SMS Message
-                tags: ''
-                dlr:
-                  period: ''
-                  rule: ''
-                  type: ''
-                  publishToWeb: false
-                  expiryDay: 0
-                  expiryHour: 0
-                  expiryMin: 0
-                  feedIds: ''
-                  bool: false
-                body: This is the body of my test SMS message
-                type: defaultNoReply
-                email:
-                  type: text/plain
-                  body: This is the body of my test Email message
-                  footer: This is the footer of my message (generally where a signature would go)
-                web:
-                  type: text/plain
-                  body: This is the content of my web publishing or Rich Push Message
-                voice:
-                  type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
-                  header: 'This is the introduction, read out prior to any key press'
-                  body: 'This is the body of the voice call, read out after the key press'
-                  footer: ''
-                  other: ''
-                responseTemplateId: 7D9A8AAA54747711
-                id: 3148356543415EE7
-                link:
-                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
-                    rel: self
-                    method: GET
-                    host: api.au.whispir.com
-                    port: -1
-                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
-                    rel: deleteTemplate
-                    method: DELETE
-                    host: api.au.whispir.com
-                    port: -1
-                  - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
-                    rel: updateTemplate
-                    method: PUT
-                    host: api.au.whispir.com
-                    port: -1
-            properties:
-              messageTemplateName:
-                type: string
-                minLength: 1
-                description: Specifies the name of the message template to be stored
-              messageTemplateDescription:
-                type: string
-                minLength: 1
-                description: 'Specifies the description of the message template, so that others can understand its purpose'
-              subject:
-                type: string
-                minLength: 1
-                description: Specifies the subject of the email message
-              tags:
-                type: string
-                description: Information which helps to label related message templates together
-              dlr:
-                type: object
-                description: dlr stands for "delivery receipt" which has a fixed object structure and is used for Whispir internal tracking purposes.
-                properties:
-                  period:
-                    type: string
-                  rule:
-                    type: string
-                  type:
-                    type: string
-                  publishToWeb:
-                    type: boolean
-                    default: false
-                  expiryDay:
-                    type: number
-                  expiryHour:
-                    type: number
-                  expiryMin:
-                    type: number
-                  feedIds:
-                    type: string
-                  bool:
-                    type: boolean
-                    default: false
-                required:
-                  - period
-                  - rule
-                  - type
-                  - publishToWeb
-                  - expiryDay
-                  - expiryHour
-                  - expiryMin
-                  - feedIds
-                  - bool
-              body:
-                type: string
-                minLength: 1
-                description: |-
-                  The SMS body.
-
-                  The maximum payload size rule applies.
-
-                  IMPORTANT: The total SMS length is 1570 characters for english text and 800 when UTF-8 characters are used (primarily non-english)
-
-                  The 1570 length is a combination of subject and body.
-                maxLength: 1570
-              type:
-                type: string
-                minLength: 1
-                description: Allows the user to modify the message behaviour for replies and DLRs (delivery receipts)
-                enum:
-                  - defaultNoReply
-                  - noDlr
-                example: defaultNoReply
-              email:
-                $ref: '#/components/schemas/email'
-              web:
-                $ref: '#/components/schemas/web'
-              voice:
-                $ref: '#/components/schemas/voice'
-              responseTemplateId:
-                type: string
-                minLength: 1
-                example: 7D9A8AAA54747711
-                description: Specifies the ID of the Response Rule that should be associated with this message template. Do not insert in the payload when unused
-              id:
-                type: string
-                minLength: 1
-                description: Specifies the ID of the template that can be referenced to use it
-                example: 3148356543415EE7
-                readOnly: true
-              link:
-                type: array
-                uniqueItems: true
-                description: Provides a list of URLs that can be used to manipulate or access the message template. This following attribute may return an empty array.
-                minItems: 0
-                items:
-                  type: object
-                  description: Provides a list of URLs that can be used to manipulate or access the message template. This following attribute may return an empty array when there are no available URLs
-                  properties:
-                    uri:
-                      type: string
-                      minLength: 1
-                      format: uri
-                      example: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
-                      description: The link to access the message template
-                      readOnly: true
-                    rel:
-                      type: string
-                      minLength: 1
-                      description: The descriptor for what the link will do
-                      default: self
-                      readOnly: true
-                    method:
-                      type: string
-                      minLength: 1
-                      description: The HTTP method to use with this particular link
-                      enum:
-                        - GET
-                        - DELETE
-                        - PUT
-                      example: GET
-                      readOnly: true
-                    host:
-                      type: string
-                      minLength: 1
-                      description: Host of the endpoint
-                      readOnly: true
-                    port:
-                      type: number
-                      description: Port number of the endpoint
-                      default: -1
-                      readOnly: true
-            required:
-              - messageTemplateName
-              - subject
-              - body
-              - type
-              - responseTemplateId
-              - id
+            $ref: '#/components/schemas/template'
           examples:
-            Template Response Object:
+            Template object:
               value:
-                messageTemplateName: Example template name
-                messageTemplateDescription: template description
-                subject: template subject
-                tags: ''
-                dlr:
-                  period: ''
-                  rule: ''
-                  type: ''
-                  publishToWeb: false
-                  expiryDay: 0
-                  expiryHour: 0
-                  expiryMin: 0
-                  feedIds: ''
-                  bool: false
-                body: template message body
-                type: defaultNoReply
+                messageTemplateName: Sample SMS Template
+                messageTemplateDescription: Template to provide an example on whispir.io
+                responseTemplateId: responseTemplateId
+                subject: Test SMS Message
+                body: This is the body of my test SMS message
                 email:
                   body: This is the body of my email message.
                   footer: This is the footer of my message.
@@ -5548,9 +5491,6 @@ components:
                       - attachmentName: photo.jpeg
                         derefUri: iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==
                         attachmentDesc: My photo
-                web:
-                  body: This is the content of my web publishing or Rich Push Message
-                  type: text/plain
                 voice:
                   header: 'This is the introduction, read out to the recipient prior to any key press.'
                   body: 'This is the body of the voice call, read out after the key press'
@@ -5560,14 +5500,44 @@ components:
                       - attachmentName: photo.jpeg
                         derefUri: iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==
                         attachmentDesc: My photo
-                responseTemplateId: 7D9A8AAA54747711
-                id: 3148356543415EE7
+                web:
+                  body: This is the content of my web publishing or Rich Push Message
+                  type: text/plain
+                social:
+                  social:
+                    - id: social
+                      body: Facebook Content
+                      type: text/plain
+                type: defaultNoReply
+                features:
+                  pushOptions:
+                    notifications: enabled
+                    escalationMins: '3'
+                    appId: appId
+                dlr:
+                  period: no example
+                  publishToWeb: 'false'
+                  rule: no example
+                  expiryDay: 1
+                  expiryHour: 1
+                  expiryMin: 1
+                  feedIds: no example
+                  bool: 'false'
+                  type: no example
                 link:
                   - uri: 'https://api.au.whispir.com/workspaces/618CAD33669AD31A/templates/3148356543415EE7'
                     rel: self
                     method: GET
-                    host: string
+                    host: api.au.whispir.com
                     port: -1
+                tags: internal
+      headers:
+        Content-Type:
+          $ref: '#/components/headers/Template-Content-Type'
+        Access-Control-Allow-Origin:
+          $ref: '#/components/headers/Access-Control-Allow-Origin'
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
     400BadRequest:
       description: 400 Bad Request Error
       content:
@@ -5603,6 +5573,7 @@ components:
                 errorSummary: Your request was malformed and could not be processed by the server. Please try again
                 errorText: Bad Request
                 errorDetail: 'java.io.EOFException: No content to map to Object due to end of input'
+      headers: {}
     401Unauthorized:
       description: 401 Unauthorized Error
       content:
@@ -5639,6 +5610,7 @@ components:
                 errorSummary: Your username and password combination was incorrect. Please check your authentication details and try again
                 errorText: Unauthorized
                 errorDetail: ''
+      headers: {}
     403Forbidden:
       description: 403 Forbidden Error
       content:
@@ -5660,6 +5632,7 @@ components:
             example-1:
               value:
                 message: Forbidden
+      headers: {}
     404NotFound:
       description: 404 Not found Error
       content:
@@ -5819,3 +5792,11 @@ components:
         enum:
           - application/vnd.whispir.messageresponse-v1+json
           - application/vnd.whispir.messageresponse-v1+xml
+    Template-Content-Type:
+      description: Template content mime type.
+      required: true
+      schema:
+        type: string
+        enum:
+          - application/vnd.whispir.template-v1+json
+          - application/vnd.whispir.template-v1+xml

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1089,7 +1089,7 @@ paths:
       tags:
         - Templates
       summary: Retrieve a template
-      description: 'Retrieves a Template object.'
+      description: Retrieves a Template object.
       operationId: getTemplatesById
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -1103,6 +1103,52 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/template'
+              examples:
+                sample response:
+                  value:
+                    messageTemplateName: Sample SMS Template
+                    messageTemplateDescription: Template to provide an example on whispir.io
+                    subject: Test SMS Message
+                    body: This is the body of my test SMS message
+                    responseTemplateId: string
+                    email:
+                      body: This is the body of my test Email message
+                      footer: This is the footer of my message (generally where a signature would go)
+                      type: text/plain
+                    voice:
+                      header: 'This is the introduction, read out prior to any key press'
+                      body: 'This is the body of the voice call, read out after the key press'
+                      type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
+                    web:
+                      body: This is the content of my web publishing or Rich Push Message
+                      type: text/plain
+                    social:
+                      social:
+                        - id: social_long
+                          body: Facebook Content.
+                          type: text/plain
+                    type: defaultNoReply
+                    features:
+                      pushOptions:
+                        notifications: enabled
+                        escalationMins: 3
+                    id: C23D6E2DD3D251BF
+                    tags: ''
+                    dir:
+                      period: ''
+                      rule: ''
+                      type: ''
+                      publishToWeb: false
+                      expiryDay: 0
+                      expiryHour: 0
+                      expiryMin: 0
+                      feedIds: ''
+                      bool: false
+                    link: []
     put:
       tags:
         - Templates
@@ -1127,7 +1173,7 @@ paths:
           application/vnd.whispir.template-v1+xml:
             schema:
               $ref: '#/components/schemas/template'
-        description: Templates object that needs to be update Templates
+        description: Templates object that needs to be updated Templates
         required: true
       responses:
         '204':
@@ -1220,7 +1266,7 @@ paths:
       tags:
         - Response Rules
       summary: Update a response rule
-      description: 'Updates a Response Rule object.'
+      description: Updates a Response Rule object.
       operationId: putResponseRulesById
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -1248,7 +1294,7 @@ paths:
       tags:
         - Response Rules
       summary: Delete a response rule
-      description: 'Deletes a Response Rule object.'
+      description: Deletes a Response Rule object.
       operationId: deleteResponseRulesById
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -1269,7 +1315,7 @@ paths:
       tags:
         - Contacts
       summary: Create a contact
-      description: 'Creates a Contact object. The Contact can be used as a recipient when sending multi-channel messages.'
+      description: Creates a Contact object. The Contact can be used as a recipient when sending multi-channel messages.
       operationId: postContacts
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -1726,7 +1772,7 @@ paths:
       tags:
         - Scenarios
       summary: List scenarios
-      description: 'Returns a list of your scenarios.'
+      description: Returns a list of your scenarios.
       operationId: getScenarios
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -1740,7 +1786,7 @@ paths:
       tags:
         - Scenarios
       summary: Retrieve a scenario
-      description: 'Retrieves a Scenario object.'
+      description: Retrieves a Scenario object.
       operationId: getScenariosById
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -1819,7 +1865,7 @@ paths:
       tags:
         - Scenarios
       summary: Update a scenario
-      description: 'Updates a Scenario object.'
+      description: Updates a Scenario object.
       operationId: putScenariosById
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -1847,7 +1893,7 @@ paths:
       tags:
         - Scenarios
       summary: Delete a scenario
-      description: 'Deletes a Scenario object.'
+      description: Deletes a Scenario object.
       operationId: deleteScenariosById
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -2183,7 +2229,7 @@ paths:
       tags:
         - Workspaces
       summary: List workspaces
-      description: 'Returns a list of your workspaces.'
+      description: Returns a list of your workspaces.
       operationId: getWorkspaces
       responses:
         '200':
@@ -2941,7 +2987,7 @@ paths:
       tags:
         - Users
       summary: List workspace users
-      description: 'Returns a list of your Users.'
+      description: Returns a list of your Users.
       operationId: getWorkspaceUsers
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -2985,7 +3031,7 @@ paths:
       tags:
         - Events
       summary: Retrieve an event
-      description: 'Retrieves an Event object.'
+      description: Retrieves an Event object.
       operationId: getEvents
       parameters:
         - $ref: '#/components/parameters/x-api-key'
@@ -3391,6 +3437,7 @@ components:
       xml:
         name: email
       title: Email
+      description: ''
       properties:
         body:
           type: string
@@ -3404,8 +3451,6 @@ components:
           enum:
             - text/plain
             - text/html
-      required:
-        - body
     voice:
       type: object
       properties:
@@ -3488,33 +3533,65 @@ components:
       title: Resource
     template:
       type: object
-      required:
-        - messageTemplateName
-        - subject
-        - body
-        - email
-        - voice
-        - web
+      xml:
+        name: template
+        prefix: ns3
+      x-tags:
+        - Templates
+      title: Template
+      x-examples:
+        example-1:
+          messageTemplateName: Sample SMS Template
+          messageTemplateDescription: Template to provide an example on whispir.io
+          responseTemplateId: string
+          subject: Test SMS Message
+          body: This is the body of my test SMS message
+          email:
+            body: This is the body of my test Email message
+            footer: This is the footer of my message (generally where a signature would go)
+            type: text/plain
+          voice:
+            header: 'This is the introduction, read out prior to any key press'
+            body: 'This is the body of the voice call, read out after the key press'
+            type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
+          web:
+            body: This is the content of my web publishing or Rich Push Message
+            type: text/plain
+          social:
+            social:
+              - id: social_long
+                body: Facebook Content.
+                type: text/plain
+          type: defaultNoReply
+          features:
+            pushOptions:
+              notifications: enabled
+              escalationMins: 3
+      description: ''
       properties:
         messageTemplateName:
           type: string
           description: Specifies the name of the message template to be used within message requests.
           example: Sample SMS Template
+          maxLength: 50
         messageTemplateDescription:
           type: string
           description: Specifies the description of the message template for others to understand its purpose.
           example: Template to provide an example on whispir.io
-        responseTemplateId:
-          type: string
-          description: Specifies the ID of the Response Rule that should be associated with this Message Template.
+          maxLength: 250
         subject:
           type: string
           description: 'Specifies the first line of the SMS message or Voice call, and the subject of the Email message.'
           example: Test SMS Message
+          maxLength: 1570
         body:
           type: string
           description: Specifies the content of the SMS message.
           example: This is the body of my test SMS message
+          maxLength: 1570
+        responseTemplateId:
+          type: string
+          description: Specifies the ID of the Response Rule that should be associated with this Message Template.
         email:
           $ref: '#/components/schemas/email'
         voice:
@@ -3529,12 +3606,10 @@ components:
           example: defaultNoReply
         features:
           $ref: '#/components/schemas/features'
-      xml:
-        name: template
-        prefix: ns3
-      x-tags:
-        - Templates
-      title: Template
+      required:
+        - messageTemplateName
+        - subject
+        - body
     responseTemplatePattern:
       type: object
       properties:
@@ -4134,6 +4209,25 @@ components:
       xml:
         name: fieldMapping
       title: Field Mapping
+    link:
+      title: link
+      type: object
+      description: 'related link of the retrieved resource '
+      properties:
+        uri:
+          type: string
+          description: specifies assoiciated API endpoint that you can use to interact with the resource
+        rel:
+          type: string
+        method:
+          type: string
+          description: 'Operation method name (e.g. "GET","POST", etc)'
+        host:
+          type: string
+        port:
+          type: integer
+        '':
+          type: string
   parameters:
     x-api-key:
       name: x-api-key
@@ -4151,4 +4245,67 @@ components:
         example: 9A4C5521FFC7B15B
       description: The identifier for the workspace.
       required: true
-  responses: {}
+  responses:
+    getTemplateById:
+      description: This is a sample response of retrieving a template
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/template'
+          examples:
+            Get a template sample response:
+              value:
+                messageTemplateName: Sample SMS Template
+                messageTemplateDescription: Template to provide an example on whispir.io
+                subject: Test SMS Message
+                body: This is the body of my test SMS message
+                responseTemplateId: string
+                email:
+                  body: This is the body of my test Email message
+                  footer: This is the footer of my message (generally where a signature would go)
+                  type: text/plain
+                voice:
+                  header: 'This is the introduction, read out prior to any key press'
+                  body: 'This is the body of the voice call, read out after the key press'
+                  type: 'ConfCall:,ConfAccountNo:,ConfPinNo:,ConfModPinNo:,Pin'
+                web:
+                  body: This is the content of my web publishing or Rich Push Message
+                  type: text/plain
+                social:
+                  social:
+                    - id: social_long
+                      body: Facebook Content.
+                      type: text/plain
+                type: defaultNoReply
+                features:
+                  pushOptions:
+                    notifications: enabled
+                    escalationMins: 3
+                id: C23D6E2DD3D251BF
+                tags: ''
+                dir:
+                  period: ''
+                  rule: ''
+                  type: ''
+                  publishToWeb: false
+                  expiryDay: 0
+                  expiryHour: 0
+                  expiryMin: 0
+                  feedIds: ''
+                  bool: false
+                link:
+                  - uri: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
+                    rel: self
+                    method: GET
+                    host: api.ap1.whispir.com
+                    port: -1
+                  - uri: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
+                    rel: updateTemplate
+                    method: PUT
+                    host: api.ap1.whispir.com
+                    port: -1
+                  - uri: 'https://api.ap1.whispir.com/workspaces/573716059009818C/templates/C23D6E2DD3D251BF'
+                    rel: deleteTemplate
+                    method: DELETE
+                    host: api.ap1.whispir.com
+                    port: -1


### PR DESCRIPTION
- Created sample error responses which then get referenced as part of /templates and /template/:{id} endpoints
- Sample Error Responses Include (400 Bad Request, 401 Unauthorized, 403 Forbidden, 404 Not Found, 415 Unsupported Media Type, 422 Unprocessable Entity and 500 Internal Server Error)
- Created sample responses for retrieving a single template and a list of templates named with (Template and Templates) within the 'Responses' folder
- Referenced "Template" response object to a successful 200 response "GET /template/:{id}" and "POST /templates" endpoints
- Referenced "Templates" response object to a successful 200 response of "GET /templates endpoint