### PR TITLE
Fix spectral action permissions

### DIFF
--- a/.github/workflows/spectral.yml
+++ b/.github/workflows/spectral.yml
@@ -1,7 +1,7 @@
 name: Run Spectral on Pull Requests
 
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
   build:

--- a/.github/workflows/spectral.yml
+++ b/.github/workflows/spectral.yml
@@ -7,6 +7,9 @@ jobs:
   build:
     name: Run Spectral
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       # Check out the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/spectral.yml
+++ b/.github/workflows/spectral.yml
@@ -7,9 +7,6 @@ jobs:
   build:
     name: Run Spectral
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       # Check out the repository
       - uses: actions/checkout@v2


### PR DESCRIPTION
By default, Github actions allow forks read-only permissions to the repository issues. This change adds those required permissions to allow forks to annotate the pull request with Spectral issues.