### PR TITLE
Add message alias documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6062,9 +6062,20 @@ components:
       x-tags:
         - Messages
       description: |-
+        ### Push Messaging
+
         Whispir allows you to send push notifications to any iOS and Android-based apps
 
         Setting up the platform to handle push notifications involves some one-time steps and some periodically repeated steps (updating push tokens). See Apps to get a clear understanding of the related steps and endpoints. Whispir doesn't support sending push notifications to device tokens directly. Read more in Contact devices about how to register the device tokens under contacts.
+
+        ### Message Aliasing
+
+        The Whispir UI allows you to configure a sender alias from which messages are sent. Instructions for alias creation can be found in [Configure message aliases](https://au.whispir.com/onlinehelp/Content/Topics-whispir-ua/administration/alias-manager/config-message-aliases.htm) within Whispir documentation.
+
+        The message alias can be attached to a message to template, to configure the the sender for the following channels:
+        * SMS - a custom mobile number, e.g. +61 123 456 789
+        * Email - a custom email address, e.g. marketing@example.com
+        * Voice - a custom mobile number, e.g. +61 123 456 789
       x-examples:
         Push Message:
           pushOptions:
@@ -6075,6 +6086,9 @@ components:
         Notifications:
           pushOptions:
             notifications: enabled
+        Message Alias:
+          aliasOption:
+            aliasName: Marketing
       properties:
         pushOptions:
           type: object
@@ -6094,6 +6108,14 @@ components:
               type: string
               description: The identifier for the registered application.
               example: appId
+        aliasOption:
+          type: object
+          description: The object defining options for message sender aliasing.
+          properties:
+            aliasName:
+              type: string
+              description: The name of the alias configured to modify the message sender.
+              example: Marketing
     resource:
       type: object
       xml:


### PR DESCRIPTION
* Add Message Alias documentation

**Screenshot Preview:**

<img width="418" alt="image" src="https://user-images.githubusercontent.com/32132657/176340725-6a5255e2-e8e4-4522-9a45-8305fda7030b.png">

**Live Preview**
https://developers.whispir.com/branches/add-alias-feature-documentation/6a3cc8ab1e555-features