### PR TITLE
Use supportive verb for language in About page

### DIFF
--- a/docs/Getting started/About.md
+++ b/docs/Getting started/About.md
@@ -16,7 +16,7 @@ Our REST API is built around simple-to-understand resource-oriented URLs. To use
 
 ## What can I do with the Whispir API?
 
-Whispir APIs let developers:
+The Whispir API enables developers to:
 
 - Create, send and retrieve multi-channel messages over 8 different channels.
 - Invoke scenario-based communications for quick, effective and targeted communications.


### PR DESCRIPTION
From Joel Zedeh-Cummings (Technical Writer):

> I'm going to be working with the marketing team to develop a new style guide for documentation, but in terms of tone, I generally prefer to use supportive verbs and avoid restrictive ones.

> By supportive verbs, I mean language like 'This helps the customer to...enables them to...empowers them to...enhances their ability to...' as this is all positive language and it emphasizes helpfulness and self sufficiency. (edited)

> Restrictive verbs include language like 'Lets the customer...allows the customer...permits the customer...' because this language is a needlessly strong, and it gives a sense that we are overly controlling of the user behavior. It's less democratic, if that makes sense.