### PR TITLE
Added 'detect-secrets' check as part of pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.3.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: package.lock.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,6 @@ repos:
     rev: v2.3.0
     hooks:
       - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.3.0
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,205 +115,234 @@
         "filename": "openapi.yaml",
         "hashed_secret": "a67fff117698ef3690bf9a13d00d9da20de4b2f5",
         "is_verified": false,
-        "line_number": 491
+        "line_number": 491,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "e59d81c0e80f3e02328a8a2d39310a5f67d5a0df",
         "is_verified": false,
-        "line_number": 1021
+        "line_number": 1021,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "7c32da181042a390e0adf1e50f1b1e84e46ed5c1",
         "is_verified": false,
-        "line_number": 1515
+        "line_number": 1515,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "190e4c5eaaeb53455ba358cad8c8b15a0d6a786f",
         "is_verified": false,
-        "line_number": 1849
+        "line_number": 1849,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "f56b1c5e5377a8088e577ddd012c8765676a382c",
         "is_verified": false,
-        "line_number": 2478
+        "line_number": 2478,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "c0db2507ed55dfcee9c54192f776eb378d300c39",
         "is_verified": false,
-        "line_number": 2899
+        "line_number": 2899,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "3656d1f25ec30f97dc1cd6539b5dad70a7ac971b",
         "is_verified": false,
-        "line_number": 3186
+        "line_number": 3186,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "419b05b36ae786712fadce183c032ec3786eb884",
         "is_verified": false,
-        "line_number": 3207
+        "line_number": 3207,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "8c1b52dfa9ff9b8fe21af9398ffd0032ebc16e99",
         "is_verified": false,
-        "line_number": 3255
+        "line_number": 3255,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "ecb1930218c025ac3dc133576f9d5659eb8f9903",
         "is_verified": false,
-        "line_number": 3674
+        "line_number": 3674,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "a421211f2448a5fcd49b7cf79b94c49505a14b38",
         "is_verified": false,
-        "line_number": 3789
+        "line_number": 3789,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "73edeef73b2fda76cbbee8759db9c7d9f469aa0c",
         "is_verified": false,
-        "line_number": 4002
+        "line_number": 4002,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "4218f1a30dbd6e07ba5530efe4902f4144c48931",
         "is_verified": false,
-        "line_number": 4806
+        "line_number": 4806,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "26c87c540abf3b56cfd1f7830bd304fb1d0d263e",
         "is_verified": false,
-        "line_number": 5031
+        "line_number": 5031,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "406fc6b596a39e29cabc8de82bf5a418bea1868e",
         "is_verified": false,
-        "line_number": 5542
+        "line_number": 5542,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "3772faaac3d60d1bcb02bf2244d588057b1bb0d2",
         "is_verified": false,
-        "line_number": 5690
+        "line_number": 5690,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "86ec7f340a16043a1a5900294c2692e4937163c1",
         "is_verified": false,
-        "line_number": 6111
+        "line_number": 6111,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "7f7abd21f9d64f45c6e99c6c8982a2f5bc050679",
         "is_verified": false,
-        "line_number": 6649
+        "line_number": 6649,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "d2c88994a5661fe364de18bd990a2b94e35b0b24",
         "is_verified": false,
-        "line_number": 6710
+        "line_number": 6710,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "f083695453849e56dcf0ca7df1dda946aef444d6",
         "is_verified": false,
-        "line_number": 6827
+        "line_number": 6827,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "faf47c98f0cdb1c45b58961c262a8235e7091d3d",
         "is_verified": false,
-        "line_number": 7331
+        "line_number": 7331,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "bc55041fe8dd89cc6d8cc8f5e38d59f958efaafc",
         "is_verified": false,
-        "line_number": 7372
+        "line_number": 7372,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "36d3a2b43b7eb9bf79b3a7a6799a88bfdd4a1869",
         "is_verified": false,
-        "line_number": 7402
+        "line_number": 7402,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "150223384705da273d580a288c9e27d5e6e647e4",
         "is_verified": false,
-        "line_number": 8484
+        "line_number": 8484,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "c8292b55500a0e025d5486d18550d1edbe2ae1db",
         "is_verified": false,
-        "line_number": 9067
+        "line_number": 9067,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "9996c43da0d60db97d00cd07d5f596568fcb33ff",
         "is_verified": false,
-        "line_number": 9111
+        "line_number": 9111,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "68fd1cdf7c60a1b3fb2efd7c0c391d4b4fddfab0",
         "is_verified": false,
-        "line_number": 9190
+        "line_number": 9190,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi.yaml",
         "hashed_secret": "fb49a2c22ab456c978b20585aed97eb7eca73506",
         "is_verified": false,
-        "line_number": 9247
+        "line_number": 9247,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi.yaml",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 9719
+        "line_number": 9719,
+        "is_secret": false
       }
     ]
   },
-  "generated_at": "2022-09-06T01:44:56Z"
+  "generated_at": "2022-09-06T04:54:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,319 @@
+{
+  "version": "1.3.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "openapi.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "a67fff117698ef3690bf9a13d00d9da20de4b2f5",
+        "is_verified": false,
+        "line_number": 491
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "e59d81c0e80f3e02328a8a2d39310a5f67d5a0df",
+        "is_verified": false,
+        "line_number": 1021
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "7c32da181042a390e0adf1e50f1b1e84e46ed5c1",
+        "is_verified": false,
+        "line_number": 1515
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "190e4c5eaaeb53455ba358cad8c8b15a0d6a786f",
+        "is_verified": false,
+        "line_number": 1849
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "f56b1c5e5377a8088e577ddd012c8765676a382c",
+        "is_verified": false,
+        "line_number": 2478
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "c0db2507ed55dfcee9c54192f776eb378d300c39",
+        "is_verified": false,
+        "line_number": 2899
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "3656d1f25ec30f97dc1cd6539b5dad70a7ac971b",
+        "is_verified": false,
+        "line_number": 3186
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "419b05b36ae786712fadce183c032ec3786eb884",
+        "is_verified": false,
+        "line_number": 3207
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "8c1b52dfa9ff9b8fe21af9398ffd0032ebc16e99",
+        "is_verified": false,
+        "line_number": 3255
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "ecb1930218c025ac3dc133576f9d5659eb8f9903",
+        "is_verified": false,
+        "line_number": 3674
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "a421211f2448a5fcd49b7cf79b94c49505a14b38",
+        "is_verified": false,
+        "line_number": 3789
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "73edeef73b2fda76cbbee8759db9c7d9f469aa0c",
+        "is_verified": false,
+        "line_number": 4002
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "4218f1a30dbd6e07ba5530efe4902f4144c48931",
+        "is_verified": false,
+        "line_number": 4806
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "26c87c540abf3b56cfd1f7830bd304fb1d0d263e",
+        "is_verified": false,
+        "line_number": 5031
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "406fc6b596a39e29cabc8de82bf5a418bea1868e",
+        "is_verified": false,
+        "line_number": 5542
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "3772faaac3d60d1bcb02bf2244d588057b1bb0d2",
+        "is_verified": false,
+        "line_number": 5690
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "86ec7f340a16043a1a5900294c2692e4937163c1",
+        "is_verified": false,
+        "line_number": 6111
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "7f7abd21f9d64f45c6e99c6c8982a2f5bc050679",
+        "is_verified": false,
+        "line_number": 6649
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "d2c88994a5661fe364de18bd990a2b94e35b0b24",
+        "is_verified": false,
+        "line_number": 6710
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "f083695453849e56dcf0ca7df1dda946aef444d6",
+        "is_verified": false,
+        "line_number": 6827
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "faf47c98f0cdb1c45b58961c262a8235e7091d3d",
+        "is_verified": false,
+        "line_number": 7331
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "bc55041fe8dd89cc6d8cc8f5e38d59f958efaafc",
+        "is_verified": false,
+        "line_number": 7372
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "36d3a2b43b7eb9bf79b3a7a6799a88bfdd4a1869",
+        "is_verified": false,
+        "line_number": 7402
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "150223384705da273d580a288c9e27d5e6e647e4",
+        "is_verified": false,
+        "line_number": 8484
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "c8292b55500a0e025d5486d18550d1edbe2ae1db",
+        "is_verified": false,
+        "line_number": 9067
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "9996c43da0d60db97d00cd07d5f596568fcb33ff",
+        "is_verified": false,
+        "line_number": 9111
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "68fd1cdf7c60a1b3fb2efd7c0c391d4b4fddfab0",
+        "is_verified": false,
+        "line_number": 9190
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi.yaml",
+        "hashed_secret": "fb49a2c22ab456c978b20585aed97eb7eca73506",
+        "is_verified": false,
+        "line_number": 9247
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "openapi.yaml",
+        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
+        "is_verified": false,
+        "line_number": 9719
+      }
+    ]
+  },
+  "generated_at": "2022-09-06T01:44:56Z"
+}


### PR DESCRIPTION
I have added `.pre-commit-config.yaml` file which performs a pre-commit hook to perform `detect-secrets` 
Here's the link to the library if you'd like to read more about it 
- https://github.com/Yelp/detect-secrets
- https://github.com/pre-commit/pre-commit-hooks

This will prevent from developers to accidentally committing code changes with potential secrets in it