### PR TITLE
fix: Trigger sdk PRs on publish event

### DIFF
--- a/.github/workflows/generate-java-sdk.yml
+++ b/.github/workflows/generate-java-sdk.yml
@@ -2,6 +2,7 @@ name: generate-java-sdk
 
 on:
   release:
+    types: [published]
 
 jobs:
   generate-java-sdk:

--- a/.github/workflows/generate-node-sdk.yml
+++ b/.github/workflows/generate-node-sdk.yml
@@ -2,6 +2,7 @@ name: generate-node-sdk
 
 on:
   release:
+    types: [published]
 
 jobs:
   generate-node-sdk:


### PR DESCRIPTION
The non-typed publish event was not triggering releases. This PR adds specificity to trigger SDK prs on release publish events.