### PR TITLE
fix: Remove id from schema spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7515,11 +7515,6 @@ components:
           mimeType: application/json
           derefUri: eyAKICAgICJzYW1wbGUiOiB0cnVlCn0=
       properties:
-        id:
-          type: string
-          example: 9B9E2425AAFEEE49E9D9112B6BAC22A9
-          description: The identifier for the resource.
-          readOnly: true
         name:
           type: string
           description: Specifies the name of the file being uploaded. The extension of the file too is allowed to be present in the name.
@@ -7721,12 +7716,6 @@ components:
           type: string
           description: Information which helps to label related message templates together
           example: campaign
-          readOnly: true
-        id:
-          type: string
-          example: 7DB65E1D8853D1C8
-          description: specifies the id of the message template
-          default: 7DB65E1D8853D1C8
           readOnly: true
       required:
         - messageTemplateName
@@ -8907,15 +8896,6 @@ components:
               host: api.au.whispir.com
               port: -1
       properties:
-        id:
-          type: string
-          maxLength: 32
-          description: |-
-            The id of the callback. 
-
-            This is the value that should be passed when referring to the callback using the API endpoints
-          example: 4452AC8359535C46
-          readOnly: true
         name:
           type: string
           description: |-
@@ -9372,11 +9352,6 @@ components:
               host: api.au.whispir.com
               port: -1
       properties:
-        id:
-          type: string
-          example: 70F2492146292826
-          description: Specifies the ID for the workspace that has been created
-          readOnly: true
         projectName:
           type: string
           description: Specifies the name of the Workspace to be created.
@@ -9958,11 +9933,6 @@ components:
                     port: -1
             description: List users response object
             properties:
-              id:
-                type: string
-                description: The ID of the user.
-                example: 4DC922649AFE370C
-                readOnly: true
               firstName:
                 type: string
                 description: The first name of the user.
@@ -10070,11 +10040,6 @@ components:
               rel: retrieveEventMessages
               method: GET
       properties:
-        id:
-          type: string
-          description: Id of the event
-          example: 888E0A343770A7D1
-          readOnly: true
         eventLabel:
           type: string
           description: Specifies the name of the label used for the messages sent under this event. This needs to match with the name of the event templates available
@@ -10266,11 +10231,6 @@ components:
         - Custom Lists
       title: Custom List
       properties:
-        id:
-          type: string
-          example: 4B4625BAEB7E4D58
-          description: Specifies the unique ID of the list
-          readOnly: true
         name:
           type: string
           example: Day of Week

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8626,8 +8626,6 @@ components:
           $ref: '#/components/schemas/Links'
       required:
         - name
-      x-stoplight:
-        id: 28a19b7a35a13
     DistributionListCollection:
       type: object
       description: list of distribution lists

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8517,12 +8517,6 @@ components:
           rules: '[{"ruleFilter" : "division", "ruleFilterActualName" : "Division", "ruleContent" : "sales"}]'
       description: 'Static Distribution Lists are manually managed and maintained. They can include Contacts, Users and other Distribution Lists'
       properties:
-        id:
-          type: string
-          description: |
-            ID of the distribution list
-          example: 5AFEB61102963D7
-          readOnly: true
         name:
           type: string
           example: My Distribution List
@@ -9040,12 +9034,6 @@ components:
       x-tags:
         - Callbacks
       properties:
-        id:
-          type: string
-          description: The unique ID of the specific call within Whispir
-          maxLength: 32
-          example: C96962B74DC57EF30F00E7097AC81A45
-          readOnly: true
         messageId:
           type: string
           minLength: 1
@@ -9472,11 +9460,6 @@ components:
               port: -1
       description: The user object.
       properties:
-        id:
-          type: string
-          description: The ID of the user.
-          example: 4DC922649AFE370C
-          readOnly: true
         userName:
           type: string
           description: Specifies the username for the account


### PR DESCRIPTION
* Remove `id` attribute from all schemas
  * `id` is included inconsistently within models, depending on the operation type. They are being entirely removed for now, pending addition to all operations that return a model