### PR TITLE
feat: WFT-335 Add Keys CRUD API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,6 +34,8 @@ tags:
     description: 'Contacts form the core of the Whispir offerings. They make up the base data to which and from which all communications are performed. The Whispir API provides secure cloud based storage for your contact information. This can then easily be retrieved by any application or device that requires access, and has permission to do so.'
     externalDocs:
       url: 'https://developers.whispir.com/c2NoOjM0ODAzNDA5-contact'
+  - name: Keys
+    description: 'Keys are used to manage user access.'
   - name: Distribution Lists
     description: Whispir’s API allows users to categorise their contacts into different groups to simplify the distribution of messages.
     externalDocs:
@@ -2991,6 +2993,319 @@ paths:
           $ref: '#/components/responses/500InternalServerError'
         '501':
           $ref: '#/components/responses/501MethodNotImplemented'
+    parameters:
+      - $ref: '#/components/parameters/workspaceId'
+  '/workspaces/{workspaceId}/keys':
+    post:
+      tags:
+        - Keys
+      x-sdkOperation: create
+      x-isPost: true
+      summary: Create a key
+      description: Creates a Key object.
+      operationId: keyCreate
+      parameters:
+        - $ref: '#/components/parameters/X-Api-Key'
+        - $ref: '#/components/parameters/Key-Accept'
+        - $ref: '#/components/parameters/Key-Content-Type'
+      requestBody:
+        content:
+          application/vnd.whispir.key-v1+json:
+            schema:
+              $ref: '#/components/schemas/Key'
+            examples:
+              Example:
+                value:
+                  id: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+                  type: basic
+                  userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+                  clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+                  accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+                  enabled: true
+                  description: Key used by Engineering for testing
+                  createdTime: '2023-01-25T02:25:33+0000'
+                  lastModifiedTime: '2022-03-29T16:30:18+11:00'
+          application/vnd.whispir.key-v1+xml:
+            schema:
+              $ref: '#/components/schemas/Key'
+            examples:
+              Example:
+                value:
+                  type: basic
+                  userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+                  clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+                  accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+                  enabled: true
+                  description: Key used by Engineering for testing
+                  createdTime: '2023-01-25T02:25:33+0000'
+                  lastModifiedTime: '2022-03-29T16:30:18+11:00'
+        description: Key object to be created
+        required: true
+      responses:
+        '201':
+          $ref: '#/components/responses/Key'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '405':
+          $ref: '#/components/responses/405MethodNotAllowed'
+        '413':
+          $ref: '#/components/responses/413EntityTooLarge'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '501':
+          $ref: '#/components/responses/501MethodNotImplemented'
+      x-internal: true
+    get:
+      tags:
+        - Keys
+      x-sdkOperation: list
+      summary: List keys
+      description: |
+        List Keys
+      operationId: keyList
+      parameters:
+        - $ref: '#/components/parameters/X-Api-Key'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/sortOrder'
+        - $ref: '#/components/parameters/sortFields'
+        - $ref: '#/components/parameters/Key-Accept'
+      responses:
+        '200':
+          $ref: '#/components/responses/Keys'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '405':
+          $ref: '#/components/responses/405MethodNotAllowed'
+        '413':
+          $ref: '#/components/responses/413EntityTooLarge'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '501':
+          $ref: '#/components/responses/501MethodNotImplemented'
+      x-internal: true
+    parameters:
+      - $ref: '#/components/parameters/workspaceId'
+  '/workspaces/{workspaceId}/keys/{keyId}':
+    get:
+      tags:
+        - Keys
+      x-sdkOperation: retrieve
+      summary: Retrieve a key
+      description: Retrieves the specified key
+      operationId: keyRetrieve
+      parameters:
+        - $ref: '#/components/parameters/X-Api-Key'
+        - name: keyId
+          in: path
+          description: The key id to fetch
+          required: true
+          schema:
+            type: string
+            example: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+        - $ref: '#/components/parameters/Key-Accept'
+        - $ref: '#/components/parameters/sortOrder'
+        - $ref: '#/components/parameters/sortFields'
+      responses:
+        '200':
+          description: OK
+          headers:
+            Content-Type:
+              $ref: '#/components/headers/Key-Content-Type'
+            Content-Length:
+              $ref: '#/components/headers/Content-Length'
+            Access-Control-Allow-Origin:
+              $ref: '#/components/headers/Access-Control-Allow-Origin'
+            Cache-Control:
+              $ref: '#/components/headers/Cache-Control'
+            Expires:
+              $ref: '#/components/headers/Expires'
+          content:
+            application/vnd.whispir.key-v1+json:
+              schema:
+                $ref: '#/components/schemas/Key'
+              examples:
+                Example:
+                  value:
+                    id: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+                    type: basic
+                    userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+                    clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+                    accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+                    enabled: true
+                    description: Key used by Engineering for testing
+                    createdTime: '2023-01-25T02:25:33+0000'
+                    lastModifiedTime: '2022-03-29T16:30:18+11:00'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '405':
+          $ref: '#/components/responses/405MethodNotAllowed'
+        '413':
+          $ref: '#/components/responses/413EntityTooLarge'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '501':
+          $ref: '#/components/responses/501MethodNotImplemented'
+      x-internal: true
+    put:
+      tags:
+        - Keys
+      x-sdkOperation: update
+      summary: Update a key
+      description: Updates the specified key
+      operationId: keyUpdate
+      parameters:
+        - $ref: '#/components/parameters/X-Api-Key'
+        - name: keyId
+          in: path
+          description: The key id to update
+          required: true
+          schema:
+            type: string
+            example: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+        - $ref: '#/components/parameters/Key-Accept'
+        - $ref: '#/components/parameters/Key-Content-Type'
+      requestBody:
+        content:
+          application/vnd.whispir.key-v1+json:
+            schema:
+              $ref: '#/components/schemas/Key'
+            examples:
+              Example:
+                value:
+                  id: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+                  type: basic
+                  userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+                  clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+                  accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+                  enabled: true
+                  description: Key used by Engineering for testing
+                  createdTime: '2023-01-25T02:25:33+0000'
+                  lastModifiedTime: '2022-03-29T16:30:18+11:00'
+          application/vnd.whispir.key-v1+xml:
+            schema:
+              $ref: '#/components/schemas/Key'
+            examples:
+              Example:
+                value:
+                  type: basic
+                  userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+                  clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+                  accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+                  enabled: true
+                  description: Key used by Engineering for testing
+                  createdTime: '2023-01-25T02:25:33+0000'
+                  lastModifiedTime: '2022-03-29T16:30:18+11:00'
+        description: Key object that needs to be updated
+        required: true
+      responses:
+        '204':
+          description: No Content
+          headers:
+            Access-Control-Allow-Origin:
+              $ref: '#/components/headers/Access-Control-Allow-Origin'
+            Cache-Control:
+              $ref: '#/components/headers/Cache-Control'
+            Expires:
+              $ref: '#/components/headers/Expires'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '405':
+          $ref: '#/components/responses/405MethodNotAllowed'
+        '413':
+          $ref: '#/components/responses/413EntityTooLarge'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '501':
+          $ref: '#/components/responses/501MethodNotImplemented'
+      x-internal: true
+    delete:
+      tags:
+        - Keys
+      x-sdkOperation: delete
+      summary: Delete a key
+      description: Deletes the speficied key
+      operationId: keyDelete
+      parameters:
+        - $ref: '#/components/parameters/X-Api-Key'
+        - name: keyId
+          in: path
+          description: The id of the key to be deleted
+          required: true
+          schema:
+            type: string
+            example: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+      responses:
+        '204':
+          description: No Content
+          headers:
+            Access-Control-Allow-Origin:
+              $ref: '#/components/headers/Access-Control-Allow-Origin'
+            Cache-Control:
+              $ref: '#/components/headers/Cache-Control'
+            Expires:
+              $ref: '#/components/headers/Expires'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '405':
+          $ref: '#/components/responses/405MethodNotAllowed'
+        '413':
+          $ref: '#/components/responses/413EntityTooLarge'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
+        '422':
+          $ref: '#/components/responses/422UnprocessibleEntity'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+        '501':
+          $ref: '#/components/responses/501MethodNotImplemented'
+      x-internal: true
     parameters:
       - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/distributionlists':
@@ -8492,6 +8807,108 @@ components:
       title: Contact Collection
       x-tags:
         - Contacts
+    Key:
+      type: object
+      x-tags:
+        - Keys
+      title: Key
+      x-examples:
+        Example:
+          id: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+          type: basic
+          userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+          clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+          accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+          enabled: true
+          description: Key used by Engineering for testing
+          createdTime: '2023-01-25T02:25:33+0000'
+          lastModifiedTime: '2022-03-29T16:30:18+11:00'
+      description: The key object.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The identifier for this key
+          example: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+          readOnly: true
+        type:
+          type: string
+          example: basic
+          enum:
+            - basic
+            - bearer
+          description: The authentication type that this Key is used for
+          readOnly: true
+        userId:
+          type: string
+          format: uuid
+          description: The user identifier associated with this Key
+          example: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+          readOnly: true
+        clientId:
+          type: string
+          format: uuid
+          description: The company identifier (client). Provided by Auth0 Management API used to revoke client access during deletion.
+          example: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+          readOnly: true
+        accountId:
+          type: string
+          format: uuid
+          description: Nextgen account id associated with this Key
+          example: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+          readOnly: true
+        enabled:
+          type: boolean
+          description: Determine if this Key is enabled or disabled
+        description:
+          type: string
+          description: User provided description usually used for identifying usage
+          example: Key used by Engineering for testing
+        createdTime:
+          type: string
+          format: date-time
+          example: '2023-01-25T02:25:33+0000'
+          description: Timestamp on when the Key has been created
+          readOnly: true
+        lastModifiedTime:
+          type: string
+          example: '2022-03-29T16:30:18+11:00'
+          description: Last Modified data and time
+          readOnly: true
+      required:
+        - type
+        - userId
+        - clientId
+        - accountId
+        - enabled
+      x-stoplight:
+        id: 00626f710da9c
+      x-internal: true
+    KeyCollection:
+      type: object
+      description: List keys object
+      properties:
+        keys:
+          type: array
+          description: list of keys
+          items:
+            $ref: '#/components/schemas/Key'
+      x-examples:
+        Example:
+          keys:
+            - id: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+              type: basic
+              userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+              clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+              accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+              enabled: true
+              description: Key used by Engineering for testing
+              createdTime: '2023-01-25T02:25:33+0000'
+              lastModifiedTime: '2022-03-29T16:30:18+11:00'
+      title: Key Collection
+      x-tags:
+        - Keys
+      x-internal: true
     DistributionList:
       type: object
       x-tags:
@@ -10317,6 +10734,30 @@ components:
           - application/vnd.whispir.contact-v1+json
           - application/vnd.whispir.contact-v1+xml
       description: Application specific mime-type.
+    Key-Content-Type:
+      name: Content-Type
+      x-isContentType: true
+      in: header
+      required: true
+      schema:
+        type: string
+        default: application/vnd.whispir.key-v1+json
+        enum:
+          - application/vnd.whispir.key-v1+json
+          - application/vnd.whispir.key-v1+xml
+      description: Application specific mime-type.
+    Key-Accept:
+      name: Accept
+      x-isContentType: true
+      in: header
+      required: true
+      schema:
+        type: string
+        default: application/vnd.whispir.key-v1+json
+        enum:
+          - application/vnd.whispir.key-v1+json
+          - application/vnd.whispir.key-v1+xml
+      description: Application specific mime-type.
     Resource-Content-Type:
       name: Content-Type
       x-isContentType: true
@@ -11497,6 +11938,70 @@ components:
           $ref: '#/components/headers/Cache-Control'
         Expires:
           $ref: '#/components/headers/Expires'
+    Key:
+      description: Example response
+      content:
+        application/vnd.whispir.key-v1+json:
+          schema:
+            $ref: '#/components/schemas/Key'
+          examples:
+            Example:
+              value:
+                id: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+                type: basic
+                userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+                clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+                accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+                enabled: true
+                description: Key used by Engineering for testing
+                createdTime: '2023-01-25T02:25:33+0000'
+                lastModifiedTime: '2022-03-29T16:30:18+11:00'
+      headers:
+        Content-Type:
+          $ref: '#/components/headers/Key-Content-Type'
+        Access-Control-Allow-Origin:
+          $ref: '#/components/headers/Access-Control-Allow-Origin'
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Cache-Control:
+          $ref: '#/components/headers/Cache-Control'
+        Expires:
+          $ref: '#/components/headers/Expires'
+        Location:
+          schema:
+            type: string
+            example: 'https://api.au.whispir.com/workspaces/9A4C5521FFC7B15B/keys/747AB7E716C1802B6476784AEB5C9BB8'
+          description: The URI to fetch details of the resource.
+    Keys:
+      description: Example response
+      content:
+        application/vnd.whispir.key-v1+json:
+          schema:
+            $ref: '#/components/schemas/KeyCollection'
+          examples:
+            Example:
+              value:
+                keys:
+                  - id: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
+                    type: basic
+                    userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
+                    clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
+                    accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
+                    enabled: true
+                    description: Key used by Engineering for testing
+                    createdTime: '2023-01-25T02:25:33+0000'
+                    lastModifiedTime: '2022-03-29T16:30:18+11:00'
+      headers:
+        Content-Type:
+          $ref: '#/components/headers/Contact-Content-Type'
+        Access-Control-Allow-Origin:
+          $ref: '#/components/headers/Access-Control-Allow-Origin'
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Cache-Control:
+          $ref: '#/components/headers/Cache-Control'
+        Expires:
+          $ref: '#/components/headers/Expires'
     Workspace:
       description: Example workspace object response
       content:
@@ -12022,6 +12527,15 @@ components:
         enum:
           - application/vnd.whispir.contact-v1+json
           - application/vnd.whispir.contact-v1+xml
+      description: Application specific mime-type.
+    Key-Content-Type:
+      required: true
+      schema:
+        type: string
+        example: application/vnd.whispir.key-v1+json
+        enum:
+          - application/vnd.whispir.key-v1+json
+          - application/vnd.whispir.key-v1+xml
       description: Application specific mime-type.
     Event-Content-Type:
       required: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2995,7 +2995,7 @@ paths:
           $ref: '#/components/responses/501MethodNotImplemented'
     parameters:
       - $ref: '#/components/parameters/workspaceId'
-  '/workspaces/{workspaceId}/keys':
+  '/keys':
     post:
       tags:
         - Keys
@@ -3006,31 +3006,17 @@ paths:
       operationId: keyCreate
       parameters:
         - $ref: '#/components/parameters/X-Api-Key'
-        - $ref: '#/components/parameters/Key-Accept'
-        - $ref: '#/components/parameters/Key-Content-Type'
+        - $ref: '#/components/parameters/Unified-Accept'
+        - $ref: '#/components/parameters/Unified-Content-Type'
       requestBody:
         content:
-          application/vnd.whispir.key-v1+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Key'
             examples:
               Example:
                 value:
                   id: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
-                  type: basic
-                  userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
-                  clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
-                  accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
-                  enabled: true
-                  description: Key used by Engineering for testing
-                  createdTime: '2023-01-25T02:25:33+0000'
-                  lastModifiedTime: '2022-03-29T16:30:18+11:00'
-          application/vnd.whispir.key-v1+xml:
-            schema:
-              $ref: '#/components/schemas/Key'
-            examples:
-              Example:
-                value:
                   type: basic
                   userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
                   clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
@@ -3079,7 +3065,7 @@ paths:
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/sortOrder'
         - $ref: '#/components/parameters/sortFields'
-        - $ref: '#/components/parameters/Key-Accept'
+        - $ref: '#/components/parameters/Unified-Accept'
       responses:
         '200':
           $ref: '#/components/responses/Keys'
@@ -3104,9 +3090,7 @@ paths:
         '501':
           $ref: '#/components/responses/501MethodNotImplemented'
       x-internal: true
-    parameters:
-      - $ref: '#/components/parameters/workspaceId'
-  '/workspaces/{workspaceId}/keys/{keyId}':
+  '/keys/{keyId}':
     get:
       tags:
         - Keys
@@ -3123,7 +3107,7 @@ paths:
           schema:
             type: string
             example: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
-        - $ref: '#/components/parameters/Key-Accept'
+        - $ref: '#/components/parameters/Unified-Accept'
         - $ref: '#/components/parameters/sortOrder'
         - $ref: '#/components/parameters/sortFields'
       responses:
@@ -3131,7 +3115,7 @@ paths:
           description: OK
           headers:
             Content-Type:
-              $ref: '#/components/headers/Key-Content-Type'
+              $ref: '#/components/headers/Unified-Content-Type'
             Content-Length:
               $ref: '#/components/headers/Content-Length'
             Access-Control-Allow-Origin:
@@ -3141,7 +3125,7 @@ paths:
             Expires:
               $ref: '#/components/headers/Expires'
           content:
-            application/vnd.whispir.key-v1+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Key'
               examples:
@@ -3193,31 +3177,17 @@ paths:
           schema:
             type: string
             example: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
-        - $ref: '#/components/parameters/Key-Accept'
-        - $ref: '#/components/parameters/Key-Content-Type'
+        - $ref: '#/components/parameters/Unified-Accept'
+        - $ref: '#/components/parameters/Unified-Content-Type'
       requestBody:
         content:
-          application/vnd.whispir.key-v1+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Key'
             examples:
               Example:
                 value:
                   id: 7f6a3d23-11f3-406c-9d72-8e8a80c248e4
-                  type: basic
-                  userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
-                  clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
-                  accountId: 30ab9bb0-373c-4f6c-b24d-1e4160af98b4
-                  enabled: true
-                  description: Key used by Engineering for testing
-                  createdTime: '2023-01-25T02:25:33+0000'
-                  lastModifiedTime: '2022-03-29T16:30:18+11:00'
-          application/vnd.whispir.key-v1+xml:
-            schema:
-              $ref: '#/components/schemas/Key'
-            examples:
-              Example:
-                value:
                   type: basic
                   userId: d7d429e0-7e1e-4b03-ba34-e486483e76f2
                   clientId: ead5ac28-47df-4d52-9d4f-de4b5e3d31a8
@@ -3306,8 +3276,6 @@ paths:
         '501':
           $ref: '#/components/responses/501MethodNotImplemented'
       x-internal: true
-    parameters:
-      - $ref: '#/components/parameters/workspaceId'
   '/workspaces/{workspaceId}/distributionlists':
     post:
       tags:
@@ -10734,29 +10702,27 @@ components:
           - application/vnd.whispir.contact-v1+json
           - application/vnd.whispir.contact-v1+xml
       description: Application specific mime-type.
-    Key-Content-Type:
+    Unified-Content-Type:
       name: Content-Type
       x-isContentType: true
       in: header
       required: true
       schema:
         type: string
-        default: application/vnd.whispir.key-v1+json
+        default: application/json
         enum:
-          - application/vnd.whispir.key-v1+json
-          - application/vnd.whispir.key-v1+xml
+          - application/json
       description: Application specific mime-type.
-    Key-Accept:
+    Unified-Accept:
       name: Accept
       x-isContentType: true
       in: header
       required: true
       schema:
         type: string
-        default: application/vnd.whispir.key-v1+json
+        default: application/json
         enum:
-          - application/vnd.whispir.key-v1+json
-          - application/vnd.whispir.key-v1+xml
+          - application/json
       description: Application specific mime-type.
     Resource-Content-Type:
       name: Content-Type
@@ -11941,7 +11907,7 @@ components:
     Key:
       description: Example response
       content:
-        application/vnd.whispir.key-v1+json:
+        application/json:
           schema:
             $ref: '#/components/schemas/Key'
           examples:
@@ -11958,7 +11924,7 @@ components:
                 lastModifiedTime: '2022-03-29T16:30:18+11:00'
       headers:
         Content-Type:
-          $ref: '#/components/headers/Key-Content-Type'
+          $ref: '#/components/headers/Unified-Content-Type'
         Access-Control-Allow-Origin:
           $ref: '#/components/headers/Access-Control-Allow-Origin'
         Content-Length:
@@ -11970,12 +11936,12 @@ components:
         Location:
           schema:
             type: string
-            example: 'https://api.au.whispir.com/workspaces/9A4C5521FFC7B15B/keys/747AB7E716C1802B6476784AEB5C9BB8'
+            example: 'https://api.au.whispir.com/keys/e2295960-1ccb-45e4-a012-bb06c4bd3fdc'
           description: The URI to fetch details of the resource.
     Keys:
       description: Example response
       content:
-        application/vnd.whispir.key-v1+json:
+        application/json:
           schema:
             $ref: '#/components/schemas/KeyCollection'
           examples:
@@ -11993,7 +11959,7 @@ components:
                     lastModifiedTime: '2022-03-29T16:30:18+11:00'
       headers:
         Content-Type:
-          $ref: '#/components/headers/Contact-Content-Type'
+          $ref: '#/components/headers/Unified-Content-Type'
         Access-Control-Allow-Origin:
           $ref: '#/components/headers/Access-Control-Allow-Origin'
         Content-Length:
@@ -12528,14 +12494,13 @@ components:
           - application/vnd.whispir.contact-v1+json
           - application/vnd.whispir.contact-v1+xml
       description: Application specific mime-type.
-    Key-Content-Type:
+    Unified-Content-Type:
       required: true
       schema:
         type: string
-        example: application/vnd.whispir.key-v1+json
+        example: application/json
         enum:
-          - application/vnd.whispir.key-v1+json
-          - application/vnd.whispir.key-v1+xml
+          - application/json
       description: Application specific mime-type.
     Event-Content-Type:
       required: true


### PR DESCRIPTION
## Summary
Update the Whispir Platform API openapi documentation to include the Keys CRUD API specifications.

## Changes
- feat: Added `Keys` tag
- feat: Added `Key` and `KeyCollection` schema
- feat: Added `Key` and `Keys` response object
- feat: Add `/keys` GET and POST endpoint
- feat: Add `/keys/{keyId}` GET, PUT, and DELETE endpoint
- feat: Mark all updates as `internal`

## Notes
- The API response is based on the standard used by existing endpoints. I used the `Contact` crud endpoints as basis. This means the response is not following jsonapi standard.
- Following the other endpoints, I also prefixed the `keys` endpoint with the `workspaces` route. Will need to verify if we are going to support workspaces.

## Output
![image](https://user-images.githubusercontent.com/6903866/215519132-67da4740-5eea-43fd-8a83-4dc812fcd5d2.png)

![image](https://user-images.githubusercontent.com/6903866/215519334-87f91a4f-12f3-4b4a-9a05-697dc63bab41.png)

![image](https://user-images.githubusercontent.com/6903866/215519563-c20c1763-2a38-40f3-9fd9-b4e9d8b84a42.png)

```
{
  "id": "7f6a3d23-11f3-406c-9d72-8e8a80c248e4",
  "type": "basic",
  "userId": "d7d429e0-7e1e-4b03-ba34-e486483e76f2",
  "clientId": "ead5ac28-47df-4d52-9d4f-de4b5e3d31a8",
  "accountId": "30ab9bb0-373c-4f6c-b24d-1e4160af98b4",
  "enabled": true,
  "description": "Key used by Engineering for testing",
  "createdTime": "2023-01-25T02:25:33+0000",
  "lastModifiedTime": "2022-03-29T16:30:18+11:00"
}
```