### PR TITLE
feat: WFT-1080 edit request body example in update a callback section

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4347,7 +4347,6 @@ paths:
             examples:
               Example 1:
                 value:
-                  id: 4452AC8359535C46
                   name: Callback Name
                   url: 'https://example.com/callback'
                   auth:
@@ -4360,12 +4359,6 @@ paths:
                   callbacks:
                     reply: disabled
                     undeliverable: disabled
-                  link:
-                    - uri: 'https://api.au.whispir.com/workspaces/9A4C5521FFC7B15B/messages/747AB7E716C1802B6476784AEB5C9BB8/messageresponses'
-                      rel: self
-                      method: GET
-                      host: api.au.whispir.com
-                      port: -1
         description: The Callback object to update
     delete:
       summary: Delete a callback


### PR DESCRIPTION
summary:
- fix the update callback request body example
- removed `id` property and `link` property (based on the comment in slack and double checked in the documents)